### PR TITLE
fix: voce meditazione non funziona su mobile e Chrome desktop

### DIFF
--- a/src/pages/admin/meditation.astro
+++ b/src/pages/admin/meditation.astro
@@ -994,6 +994,9 @@ const quotesJson = JSON.stringify(allQuotes);
         } else if (voiceRetries < 10) {
           voiceRetries++;
           setTimeout(loadVoice, 500);
+        } else if (voices.length > 0) {
+          // No Italian voice found — use default voice as fallback so speech still works
+          cachedVoice = voices[0];
         }
       }
       if (window.speechSynthesis) {


### PR DESCRIPTION
## Summary

### Fix audio meditazione
La voce guidata non si sentiva su mobile e Chrome desktop:
- **Bug Chrome 15 secondi**: keep-alive con `pause()/resume()` ogni 10s
- **Nessuna voce italiana**: fallback alla voce di default del sistema
- **Autoplay policy mobile**: AudioContext e speechSynthesis inizializzati al tap
- **Caricamento voci asincrono**: retry automatico (fino a 10 tentativi)
- **Ritorno dal background**: AudioContext ripristinato

### Percorso meditazione migliorato
- Fasi accorciate (2 mesi invece di 3) per più varietà prima
- Nuova fase "Gentilezza" (Metta) al mese 4-5, prima di Vipassana
- Voce guidata ON per i primi 30 giorni, poi OFF con suggerimento
- Scelta manuale voce salvata in localStorage

### Chime contati per orientarsi ad occhi chiusi
- 1 chime = step 1, 2 chime = step 2, ecc.
- Funziona sia con voce ON che OFF

### Specs documentazione
Aggiunte 9 spec in `docs/` per tutte le feature del progetto:
- `analytics-spec.md` (esistente)
- `blog-spec.md`, `comments-spec.md`, `contact-spec.md`
- `lastfm-spec.md`, `letterboxd-spec.md`, `strava-spec.md`
- `meal-plan-spec.md`, `body-comp-spec.md`, `meditation-spec.md`

Aggiunta regola in CLAUDE.md: aggiornare sempre le spec alla fine di ogni feature.

## Test plan
- [ ] Voce funziona su Chrome desktop
- [ ] Voce funziona su Chrome Android / Safari iOS
- [ ] Chime contati: 1,2,3,4 chime per step 1,2,3,4
- [ ] Dopo 30 giorni di pratica, voce OFF di default
- [ ] Toggle voce persiste in localStorage
- [ ] Specs leggibili e accurate

https://claude.ai/code/session_01RCeuibt6sdNUUPbXnKvMEU