### PR TITLE
fix: audio meditazione + percorso migliorato + specs progetto

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,3 +109,7 @@ When making significant changes (new features, architectural decisions, design c
 - How it works (architecture, data flow)
 - Setup instructions if new env vars or services are needed
 - Keep it concise but complete enough for a future developer (or future you) to understand the reasoning
+
+## Specs
+
+Le spec di ogni feature si trovano in `docs/{feature-name}-spec.md`. Alla fine di ogni feature (nuova o modificata), **aggiorna sempre la spec corrispondente** in `docs/`. Se la spec non esiste, creala. Se esiste, aggiornala con le modifiche fatte.

--- a/docs/blog-spec.md
+++ b/docs/blog-spec.md
@@ -1,0 +1,165 @@
+# Blog System — Spec
+
+## Obiettivo
+
+Fornire un sistema di blog statico con supporto i18n (italiano/inglese), paginazione, filtro per tag, ricerca lato client e articoli correlati. I contenuti sono scritti in Markdown tramite Astro Content Collections e generati staticamente al build time.
+
+## Architettura
+
+```
+                         BUILD TIME
+                             |
+              +--------------+--------------+
+              |                             |
+   Content Collections               API Search Index
+   src/content/blog/                  /api/search.json
+      it/*.md                              |
+      en/*.md                              |
+              |                            |
+     +--------+--------+                   |
+     |        |        |                   |
+  [slug]  [...page]  [tag]                 |
+  pagina   listing   listing               |
+  singola  paginato  per tag               |
+     |        |        |                   |
+     |     +--+--+     |                   |
+     |     |     |     |                   |
+     |   Card  Card  Card                  |
+     |                                     |
+     +--- RelatedPosts                     |
+     |    (tag similarity)                 |
+     |                                     |
+     +--- Comments                         |
+                                           |
+                    RUNTIME (client)       |
+                         |                 |
+                    BlogSearch  <----------+
+                    fetch JSON
+                    filtro locale
+                    risultati dropdown
+```
+
+## Dati / Schema
+
+### Frontmatter dei post (`src/content/blog/{locale}/{slug}.md`)
+
+| Campo              | Tipo       | Obbligatorio | Note                                      |
+|--------------------|------------|--------------|-------------------------------------------|
+| `title`            | `string`   | si           | Titolo del post                            |
+| `date`             | `string`   | si           | Data di pubblicazione (ISO)                |
+| `extract`          | `string`   | si           | Estratto/descrizione breve                 |
+| `tags`             | `string[]` | si           | Tag per categorizzazione e correlati       |
+| `coverImage`       | `string`   | si           | URL immagine di copertina (anche esterno)  |
+| `coverAuthorLink`  | `string`   | no           | Link all'autore della cover                |
+| `coverAuthorName`  | `string`   | no           | Nome autore della cover                    |
+| `coverDescription` | `string`   | no           | Alt text / descrizione della cover         |
+
+### Indice di ricerca (generato da `/api/search.json`)
+
+```json
+[
+  {
+    "title": "string",
+    "slug": "string",
+    "lang": "it | en",
+    "extract": "string",
+    "date": "string",
+    "tags": ["string"]
+  }
+]
+```
+
+## API Endpoints
+
+### `GET /api/search.json`
+
+Endpoint statico (pre-renderizzato al build time) che restituisce tutti i post di tutte le lingue come array JSON.
+
+- **Risposta 200**: array di oggetti `{ title, slug, lang, extract, date, tags }`
+- **Risposta 500**: array vuoto `[]`
+- **Cache**: `Cache-Control: public, s-maxage=300` (5 minuti)
+- **Nota**: l'indice include tutti i post di tutte le lingue; il filtro per lingua avviene lato client
+
+## Componenti UI
+
+### `Card.astro`
+
+Card per la preview di un post nella lista. Mostra immagine ottimizzata (`astro:Image`, 600x340, lazy loading), data, massimo 2 tag, titolo e un estratto troncato a 120 caratteri. Il link punta a `/blog/{slug}/` (IT) o `/en/blog/{slug}/` (EN). Include effetti visivi (overlay, glitch, pixelate) sulla card image.
+
+**Props**: `title`, `extract`, `date`, `coverImage`, `tags`, `slug`, `lang?` (default `"it"`)
+
+### `BlogSearch.astro`
+
+Componente di ricerca client-side con dropdown dei risultati. Al mount carica l'intero indice da `/api/search.json` tramite `fetch`. La ricerca parte da 2+ caratteri e filtra per corrispondenza (case-insensitive) su `title`, `extract` e `tags`. I risultati mostrano il titolo con evidenziazione del termine cercato (`<mark>`). Si chiude con Escape o con il pulsante di clear.
+
+**Limiti**: non filtra per lingua (mostra risultati IT e EN mescolati); i link puntano sempre a `/blog/{slug}/` senza prefisso lingua.
+
+### `RelatedPosts.astro`
+
+Mostra fino a `maxPosts` (default 6) articoli correlati basati sulla similarita dei tag. L'algoritmo conta i tag in comune; a parita ordina per data decrescente. Esclude il post corrente. Filtra per lingua. Renderizza una griglia responsiva di `Card`.
+
+**Props**: `currentSlug`, `currentTags`, `maxPosts?` (default 6), `lang?` (default `"it"`)
+
+## i18n
+
+- La lingua viene determinata dalla directory del contenuto (`it/` o `en/`) tramite `getLangFromId()`
+- Utility in `src/i18n/utils.ts`:
+  - `getLangFromUrl(url)` — estrae la lingua dal path URL
+  - `getLangFromId(id)` — estrae la lingua dall'ID della content collection (primo segmento del path)
+  - `getSlugFromId(id)` — estrae lo slug dall'ID (ultimo segmento del path)
+  - `useTranslations(lang)` — restituisce una funzione `t(key)` con fallback alla lingua default
+  - `getLocalizedPath(path, lang)` — aggiunge il prefisso `/en/` se necessario
+- Chiavi di traduzione rilevanti per il blog: `blog.relatedPosts`, `blog.readMore`, `blog.readingTime`, `blog.tags`
+- Configurazione: italiano senza prefisso URL, inglese con prefisso `/en/`
+- Le pagine IT e EN sono file separati (`src/pages/blog/` e `src/pages/en/blog/`)
+
+## Paginazione
+
+- Gestita da `paginate()` di Astro con `pageSize: 6`
+- L'oggetto `pagination` passato al layout `Blog.astro` contiene: `currentPage`, `lastPage`, `url.prev`, `url.next`, `url.current`, `basePath`
+- Le pagine tag (`/tag/{tag}/`) usano lo stesso meccanismo con base path `/tag/{tag}/`
+- Le pagine tag hanno `noindex` per evitare indicizzazione duplicata
+
+## File coinvolti
+
+| File | Ruolo |
+|------|-------|
+| `src/pages/blog/[slug].astro` | Pagina singola post (IT) |
+| `src/pages/blog/[...page].astro` | Listing paginato (IT) |
+| `src/pages/tag/[tag]/[...page].astro` | Listing filtrato per tag (IT) |
+| `src/pages/api/search.json.ts` | Endpoint indice di ricerca |
+| `src/components/Card.astro` | Card preview post |
+| `src/components/Card.css` | Stili co-locati della Card |
+| `src/components/BlogSearch.astro` | Ricerca client-side |
+| `src/components/RelatedPosts.astro` | Articoli correlati |
+| `src/components/Comments.astro` | Sistema commenti (inline nel post) |
+| `src/components/FormattedDate.astro` | Formattazione date |
+| `src/components/Tag.astro` | Componente singolo tag |
+| `src/layouts/BlogPost.astro` | Layout pagina singola |
+| `src/layouts/Blog.astro` | Layout listing |
+| `src/i18n/utils.ts` | Helper i18n (lang/slug extraction) |
+| `src/i18n/ui.ts` | Dizionario traduzioni |
+| `src/content/blog/it/*.md` | Contenuti italiano |
+| `src/content/blog/en/*.md` | Contenuti inglese |
+
+## Dipendenze
+
+- **Astro 5** — framework SSG, content collections (glob loader), `paginate()`, `astro:Image`
+- **astro:content** — `getCollection()`, `render()` per i post Markdown
+- **Nessuna libreria di ricerca esterna** — la ricerca e puramente client-side con `String.includes()`
+
+## Env vars
+
+Nessuna variabile d'ambiente richiesta per il sistema blog in se. L'indice di ricerca e i contenuti sono tutti generati staticamente al build time.
+
+(Le env vars `TURSO_*` e `ADMIN_TOKEN` servono al sistema commenti, che e integrato nelle pagine post ma e un sistema separato.)
+
+## Limiti e trade-off
+
+- **Ricerca non filtrata per lingua**: `BlogSearch` carica tutti i post (IT + EN) e non filtra per lingua corrente. I link nei risultati puntano sempre a `/blog/{slug}/` (percorso italiano).
+- **Ricerca in-memory**: l'intero indice viene scaricato al primo utilizzo. Funziona bene per blog di dimensioni medie, ma non scala per migliaia di post.
+- **Nessuna ricerca full-text**: il filtro e basato su `includes()` su titolo, estratto e tag. Non supporta fuzzy matching, stemming o ranking per rilevanza.
+- **Paginazione statica**: la dimensione pagina (6 post) e fissa nel codice, non configurabile senza modifica.
+- **Pagine duplicate IT/EN**: le route per italiano e inglese sono file Astro separati con logica quasi identica. Il filtro per lingua e manuale (`getLangFromId() === 'it'`).
+- **Tag case-insensitive ma non normalizzati**: il confronto tag usa `toLowerCase()` ma lo slug del tag nel URL mantiene il case originale del primo tag trovato.
+- **Immagini cover esterne**: le cover possono essere URL esterni, il che richiede configurazione Astro per i domini consentiti nelle ottimizzazioni immagini.

--- a/docs/body-comp-spec.md
+++ b/docs/body-comp-spec.md
@@ -1,0 +1,170 @@
+# Body Composition — Spec
+
+## Obiettivo
+
+Dashboard admin privata per monitorare l'andamento della composizione corporea nel tempo tramite misurazioni BIA (Bioimpedenza). Visualizza grafici storici, metriche di riepilogo, piano nutrizionale target e consigli giornalieri motivazionali.
+
+## Architettura
+
+```
+┌──────────────────────────────────────────────────────┐
+│                      Browser                          │
+│  GET /admin/body-comp?token=ADMIN_TOKEN               │
+└───────────────────────┬──────────────────────────────┘
+                        │
+                        ▼
+┌──────────────────────────────────────────────────────┐
+│            Astro SSR (Netlify Function)                │
+│                                                        │
+│  1. Verifica token via timeSafeEqual()                 │
+│  2. Importa measurements.json come modulo              │
+│  3. Estrae measurements[], nutrition_plan, sources[]   │
+│  4. Passa dati al client via define:vars               │
+└───────────────────────┬──────────────────────────────┘
+                        │
+                        ▼
+┌──────────────────────────────────────────────────────┐
+│           Client-side (script is:inline)               │
+│                                                        │
+│  Chart.js 4.4.7 (CDN)                                 │
+│  - 5 grafici linea (composizione, BF%, PhA, BMI, BMR) │
+│  - 2 grafici donut (composizione attuale, macros)      │
+│  - 1 grafico barre (kcal settimanali)                  │
+│  - 6 stat card con delta vs misurazione precedente     │
+│  - Tabella storica completa                            │
+│  - 3 tip giornalieri (ruotano per day-of-year)         │
+└───────────────────────┬──────────────────────────────┘
+                        │
+                        ▼
+┌──────────────────────────────────────────────────────┐
+│          data/body-comp/measurements.json              │
+│                                                        │
+│  File JSON statico con:                                │
+│  - subject (anagrafica)                                │
+│  - sources[] (medici/software)                         │
+│  - measurements[] (serie storica BIA)                  │
+│  - nutrition_plan (macros + kcal settimanali)          │
+└──────────────────────────────────────────────────────┘
+```
+
+## Dati / Schema
+
+### `measurements.json` — struttura root
+
+```json
+{
+  "subject": { "name": "...", "dob": "YYYY-MM-DD", "sex": "M" },
+  "sources": [ ... ],
+  "measurements": [ ... ],
+  "nutrition_plan": { ... }
+}
+```
+
+### `sources[]`
+
+| Campo | Tipo | Descrizione |
+|---|---|---|
+| `id` | string | Identificativo ("mancini", "cardinali") |
+| `doctor` | string | Nome del professionista |
+| `role` | string | Qualifica (es. "Biologo Nutrizionista") |
+| `software` | string | Software BIA utilizzato |
+| `height_cm` | number | Altezza registrata (varia per fonte: 168 vs 167) |
+| `notes` | string | Note sulla normalizzazione dei valori |
+
+### `measurements[]`
+
+| Campo | Tipo | Presente in | Descrizione |
+|---|---|---|---|
+| `date` | string | tutti | Data misurazione (YYYY-MM-DD) |
+| `source` | string | tutti | Riferimento a sources[].id |
+| `weight_kg` | number | tutti | Peso corporeo totale |
+| `bmi` | number | tutti | Body Mass Index |
+| `pha_deg` | number | tutti | Angolo di fase (gradi) |
+| `bmr_kcal` | number | tutti | Metabolismo basale |
+| `bcm_kg` | number | tutti | Body Cell Mass |
+| `ffm_kg` | number | tutti | Fat-Free Mass |
+| `fm_kg` | number | tutti | Fat Mass |
+| `fm_pct` | number | tutti | Fat Mass percentuale |
+| `tbw_l` | number | tutti | Total Body Water (litri) |
+| `rz_ohm` | number | tutti | Resistenza (impedenza) |
+| `xc_ohm` | number | tutti | Reattanza |
+| `bcm_pct_ffm` | number | solo cardinali | BCM come % di FFM |
+| `ffm_pct` | number | solo cardinali | FFM come % del peso |
+| `tbw_pct` | number | solo cardinali | TBW come % del peso |
+| `ecw_l` | number | solo cardinali | Extra-Cellular Water (litri) |
+| `ecw_pct_tbw` | number | solo cardinali | ECW come % di TBW |
+| `nak` | number | solo cardinali | Rapporto Na/K |
+
+Serie storica: 12 misurazioni dal 2023-09-28 al 2026-03-17. Le prime 8 da "mancini", le ultime 5 da "cardinali".
+
+### `nutrition_plan`
+
+```json
+{
+  "date": "2026-03-17",
+  "source": "cardinali",
+  "macros_target": { "protein_pct": 29.56, "fat_pct": 22.62, "carb_pct": 47.53 },
+  "macros_average": { "protein_pct": 28.71, "fat_pct": 22.69, "carb_pct": 46.35 },
+  "daily_kcal": [1800, 1720, 1790, 1760, 1720, 2100, 1800],
+  "daily_labels": ["Lun", "Mar", "Mer", "Gio", "Ven", "Sab", "Dom"]
+}
+```
+
+## Componenti UI
+
+| Componente | Descrizione |
+|---|---|
+| **Daily Tips** | 3 card motivazionali (Benessere, Costanza, Meditazione) che ruotano in base al giorno dell'anno (`dayOfYear % array.length`). ~31 messaggi per categoria. Focus su anti-alcol e disciplina. |
+| **Source Legend** | Legenda con dot colorati per distinguere le due fonti dati (Mancini = teal, Cardinali = oro) |
+| **Summary Grid** | 6 stat card (Peso, FM%, FFM, BMI, PhA, BMR) con valore attuale, delta vs precedente (verde/rosso con inversione semantica per peso e FM%), tooltip informativo |
+| **Composizione Corporea** | Grafico linea full-width con 3 serie: Peso, FFM, FM. Punti colorati per fonte |
+| **Body Fat %** | Grafico linea con zone colorate di sfondo (verde <15%, giallo 15-20%, rosso >20%) |
+| **Angolo di Fase** | Grafico linea con banda verde tratteggiata (range sano 5-7 gradi) |
+| **BMI** | Grafico linea con 4 zone colorate (sottopeso, normopeso, sovrappeso, obeso) |
+| **Metabolismo Basale** | Grafico linea con area fill verde |
+| **Donut Composizione** | Donut chart FM vs FFM dell'ultima misurazione, peso totale al centro |
+| **Donut Macros** | Donut chart proteine/lipidi/glucidi del piano nutrizionale target, kcal medie giornaliere al centro |
+| **Kcal Settimanali** | Grafico a barre per giorno della settimana, con linea media tratteggiata. Barre sopra la media in giallo, sotto in teal |
+| **Storico Misurazioni** | Tabella completa con tutte le misurazioni (ordine cronologico inverso), badge colorato per fonte |
+| **AdminNav** | Navigazione admin condivisa |
+
+### Logica delta
+
+La funzione `delta(curr, prev, unit, invert)` calcola la differenza tra ultima e penultima misurazione. Il parametro `invert` inverte la semantica del colore: per peso e FM% un aumento e negativo (rosso), per FFM, PhA e BMR un aumento e positivo (verde).
+
+## File coinvolti
+
+| File | Ruolo |
+|---|---|
+| `src/pages/admin/body-comp.astro` | Pagina SSR, layout, stili, logica grafici |
+| `data/body-comp/measurements.json` | Dati BIA storici + piano nutrizionale |
+| `src/components/AdminNav.astro` | Navigazione admin condivisa |
+| `src/lib/auth.ts` | Funzione `timeSafeEqual()` per verifica token |
+
+## Dipendenze
+
+| Dipendenza | Versione | Caricamento | Uso |
+|---|---|---|---|
+| **Chart.js** | 4.4.7 | CDN (`cdn.jsdelivr.net`) | Tutti i grafici (linea, donut, barre) |
+| **Astro 5** | — | Framework | SSR + `define:vars` per passare dati al client |
+
+Nessun database. Nessuna API esterna a runtime.
+
+## Env vars
+
+| Variabile | Uso |
+|---|---|
+| `ADMIN_TOKEN` | Token segreto per autenticazione. Passato come query parameter `?token=` |
+
+## Limiti e trade-off
+
+- **Dati in file JSON statico**: le misurazioni vanno aggiunte manualmente a `measurements.json` e richiedono un redeploy. Non esiste un form di inserimento. Scelta voluta: le misurazioni BIA avvengono ogni 2-3 mesi.
+- **Due fonti con campi diversi**: il passaggio da Dott.ssa Mancini a Dott. Cardinali ha introdotto campi aggiuntivi (`ecw_l`, `nak`, `bcm_pct_ffm`, ecc.) presenti solo nelle misurazioni recenti. I grafici usano solo i campi comuni.
+- **Altezza discordante**: 168 cm (Mancini) vs 167 cm (Cardinali). Il BMI e calcolato da ciascuna fonte con la propria altezza, quindi non e perfettamente comparabile.
+- **Chart.js da CDN**: dipendenza esterna a runtime. Se il CDN non e raggiungibile, i grafici non vengono renderizzati (nessun fallback).
+- **Script inline monolitico**: tutta la logica client (8 grafici, tabella, tips) e in un unico blocco `<script is:inline>`. Non e modulare ne testabile.
+- **Consigli giornalieri statici**: i tip ruotano deterministicamente per day-of-year. Non c'e personalizzazione ne tracciamento.
+- **Autenticazione via query parameter**: il token e visibile nell'URL. Sufficiente per uso personale.
+- **`prerender = false`**: pagina renderizzata server-side ad ogni richiesta (Netlify Function).
+- **Nessun supporto i18n**: pagina solo in italiano.
+- **File JSON fuori da `src/`**: `measurements.json` risiede in `data/` (root del progetto), non in `src/`. Importato con path relativo `../../../data/body-comp/measurements.json`.

--- a/docs/comments-spec.md
+++ b/docs/comments-spec.md
@@ -1,0 +1,235 @@
+# Comments System — Spec
+
+## Obiettivo
+
+Fornire un sistema di commenti self-hosted per i post del blog, senza dipendere da servizi SaaS esterni (Disqus, Giscus, ecc.). I visitatori possono lasciare commenti sulle pagine del blog; ogni commento passa attraverso una moderazione manuale prima di diventare visibile. L'admin riceve una notifica via email alla ricezione di un nuovo commento e puo approvare o eliminare i commenti da un'interfaccia dedicata.
+
+## Architettura
+
+```
+                           VISITATORE
+                               |
+                     [Comments.astro component]
+                        |              |
+                   GET /api/comments   POST /api/comments
+                   (carica approvati)  (invia nuovo)
+                        |              |
+                        v              v
+                   +---------+    +---------+    +------------+
+                   | Turso   |    | Turso   |--->| Resend API |
+                   | (READ)  |    | (WRITE) |    | (email)    |
+                   +---------+    +---------+    +------------+
+                        ^              ^
+                        |              |
+                   GET /api/admin/     PATCH /api/admin/
+                   comments            comments
+                        |              |
+                     [admin/comments.astro]
+                               |
+                            ADMIN
+                   (autenticato via token)
+```
+
+Flusso dati:
+
+1. Il visitatore apre una pagina blog -> il componente `Comments.astro` carica i commenti approvati via `GET /api/comments?pageId=...`
+2. Il visitatore compila il form -> `POST /api/comments` inserisce il commento nel DB con `approved = 0` (default) e invia una notifica email via Resend
+3. L'admin accede a `/admin/comments?token=ADMIN_TOKEN` -> la pagina carica i commenti pendenti via `GET /api/admin/comments?status=pending`
+4. L'admin approva o elimina -> `PATCH /api/admin/comments` con `{ id, action }` aggiorna o cancella il record
+5. Dopo l'approvazione il commento diventa visibile ai visitatori
+
+## Dati / Schema DB
+
+Database: **Turso** (SQLite edge, via `@libsql/client`).
+
+Tabella `comments`:
+
+| Campo        | Tipo    | Note                                           |
+| ------------ | ------- | ---------------------------------------------- |
+| `id`         | INTEGER | Primary key, autoincrement (implicito SQLite)  |
+| `page_id`    | TEXT    | Identificativo della pagina (es. slug del post)|
+| `name`       | TEXT    | Nome dell'autore (max 100 caratteri)           |
+| `email`      | TEXT    | Email dell'autore (max 254 caratteri)          |
+| `text`       | TEXT    | Contenuto del commento (max 5000 caratteri)    |
+| `approved`   | INTEGER | 0 = pendente (default), 1 = approvato         |
+| `created_at` | TEXT    | Timestamp di creazione (default SQLite)        |
+
+Query di lettura pubblica filtrano per `approved = 1` e ordinano per `created_at ASC`.
+Query admin filtrano per `approved = 0` (pendenti) o `approved = 1` (approvati) e ordinano per `created_at DESC`.
+
+## API Endpoints
+
+### `GET /api/comments`
+
+| Proprieta       | Valore                                          |
+| --------------- | ----------------------------------------------- |
+| **Metodo**      | GET                                             |
+| **Path**        | `/api/comments`                                 |
+| **Autenticazione** | Nessuna (endpoint pubblico)                  |
+| **Query params** | `pageId` (obbligatorio)                        |
+| **Response 200** | `[{ id, name, text, created_at }, ...]`        |
+| **Response 400** | `{ error: "pageId required" }`                 |
+
+Logica: seleziona dalla tabella `comments` i record con `page_id` corrispondente e `approved = 1`, ordinati per `created_at ASC`. L'email non viene esposta nella risposta pubblica.
+
+---
+
+### `POST /api/comments`
+
+| Proprieta       | Valore                                          |
+| --------------- | ----------------------------------------------- |
+| **Metodo**      | POST                                            |
+| **Path**        | `/api/comments`                                 |
+| **Autenticazione** | Nessuna (endpoint pubblico)                  |
+| **Content-Type** | `application/json`                              |
+| **Request body** | `{ pageId, name, email, text, website }`       |
+| **Response 201** | `{ ok: true }` (commento inserito)             |
+| **Response 200** | `{ ok: true }` (honeypot attivato, silenzioso) |
+| **Response 400** | `{ error: "All fields are required" }` oppure `{ error: "Field too long" }` oppure `{ error: "Invalid email" }` |
+
+Logica:
+
+1. **Honeypot**: se il campo `website` e valorizzato, il commento viene scartato silenziosamente (risposta 200 per non rivelare il meccanismo ai bot).
+2. **Validazione campi**: `pageId`, `name`, `email`, `text` obbligatori e non vuoti dopo trim.
+3. **Validazione lunghezza**: `name` <= 100, `email` <= 254, `text` <= 5000 caratteri.
+4. **Validazione email**: regex `/^[^\s@]+@[^\s@]+\.[^\s@]+$/`.
+5. **Inserimento**: `INSERT INTO comments (page_id, name, email, text)` — il campo `approved` resta al default (`0`).
+6. **Notifica email**: chiama `notifyNewComment()` che invia un'email via Resend API all'indirizzo dell'admin (`valerio.narcisi@gmail.com`) con i dettagli del commento e un link diretto alla pagina di moderazione. La notifica e fire-and-forget: se fallisce non blocca la risposta.
+
+---
+
+### `GET /api/admin/comments`
+
+| Proprieta       | Valore                                          |
+| --------------- | ----------------------------------------------- |
+| **Metodo**      | GET                                             |
+| **Path**        | `/api/admin/comments`                           |
+| **Autenticazione** | Bearer token (`Authorization: Bearer <ADMIN_TOKEN>`) |
+| **Query params** | `status` (opzionale, default `"pending"`, valori: `"pending"` / `"approved"`) |
+| **Response 200** | `[{ id, page_id, name, email, text, approved, created_at }, ...]` |
+| **Response 401** | `"Unauthorized"`                               |
+
+Logica: converte `status` in valore numerico (`approved` = 1, altrimenti 0), seleziona i record corrispondenti ordinati per `created_at DESC`. L'email e inclusa nella risposta admin. L'autenticazione usa `verifyBearerToken()` che effettua un confronto time-safe del token.
+
+---
+
+### `PATCH /api/admin/comments`
+
+| Proprieta       | Valore                                          |
+| --------------- | ----------------------------------------------- |
+| **Metodo**      | PATCH                                           |
+| **Path**        | `/api/admin/comments`                           |
+| **Autenticazione** | Bearer token (`Authorization: Bearer <ADMIN_TOKEN>`) |
+| **Content-Type** | `application/json`                              |
+| **Request body** | `{ id: number, action: "approve" | "delete" }` |
+| **Response 200** | `{ ok: true }`                                 |
+| **Response 400** | `{ error: "Invalid action" }`                  |
+| **Response 401** | `"Unauthorized"`                               |
+
+Logica:
+
+- `action: "approve"` -> `UPDATE comments SET approved = 1 WHERE id = ?`
+- `action: "delete"` -> `DELETE FROM comments WHERE id = ?`
+
+## Componenti UI
+
+### `Comments.astro` (componente pubblico)
+
+Riceve due props:
+- `pageId: string` — identificativo della pagina
+- `lang: "it" | "en"` — lingua per le label
+
+**Layout**:
+- Sezione con titolo "Commenti" / "Comments"
+- Lista commenti (`Comments-list`) con `aria-live="polite"` per accessibilita
+- Form di invio con campi: Nome, Email, campo honeypot nascosto (Website), Commento, bottone Invia
+- Messaggio di stato post-invio (successo/errore)
+
+**Comportamento**:
+- Al caricamento: fetch `GET /api/comments?pageId=...` e rendering della lista. Se vuota, mostra messaggio "Nessun commento ancora".
+- Al submit: fetch `POST /api/comments` con dati JSON. In caso di successo, mostra messaggio di conferma e resetta il form. In caso di errore, mostra messaggio di errore.
+- Le date vengono formattate con `toLocaleDateString()` nella locale corretta (`it-IT` o `en-US`).
+- L'output HTML viene sanitizzato con `escapeHtml()` (creazione di text node nel DOM).
+
+**CSS** (`Comments.css`, co-located):
+- Mobile-first, usa variabili CSS globali del tema
+- Il campo honeypot (`Comments-hp`) e posizionato fuori schermo con `position: absolute; left: -9999px`
+
+**i18n**: label duplicate nel frontmatter (per SSR) e nello script inline (per client-side), in entrambe le lingue (IT/EN).
+
+---
+
+### `admin/comments.astro` (pagina admin)
+
+**Autenticazione**: confronto time-safe del query param `token` con `ADMIN_TOKEN`. Se non valido, ritorna 401.
+
+**Layout**:
+- Header con navigazione admin (`AdminNav` component)
+- Titolo "Comments"
+- Tab "Pending" / "Approved" per filtrare i commenti
+- Conteggio commenti
+- Tabella con colonne: Page, Name, Email, Comment, Date, Actions
+- Messaggio "No comments found" se la lista e vuota
+
+**Comportamento**:
+- Al caricamento: fetch dei commenti pendenti via `GET /api/admin/comments?status=pending`
+- Click su tab: ricarica i commenti con lo status corrispondente
+- Bottone "Approve" (solo su commenti pendenti): chiama `PATCH /api/admin/comments` con `action: "approve"`, poi ricarica
+- Bottone "Delete": chiama `PATCH /api/admin/comments` con `action: "delete"`, poi ricarica
+- Il token viene passato dallo script Astro al client via `define:vars`
+- Meta tag `robots: noindex, nofollow` e `referrer: no-referrer` per proteggere la pagina
+
+**Stile**: inline nella pagina, tema scuro (`background: #0a0a0c`), colori coerenti col brand (`#c9a84c` gold, `#4ecdc4` cyan, `#e74c3c` rosso).
+
+## File coinvolti
+
+| File | Scopo |
+| ---- | ----- |
+| `src/pages/api/comments.ts` | Endpoint pubblico GET/POST per lettura e invio commenti |
+| `src/pages/api/admin/comments.ts` | Endpoint admin GET/PATCH per moderazione commenti |
+| `src/pages/admin/comments.astro` | Pagina admin per la moderazione dei commenti |
+| `src/components/Comments.astro` | Componente front-end per visualizzare e inviare commenti |
+| `src/components/Comments.css` | Stili del componente commenti |
+| `src/lib/turso.ts` | Client singleton per Turso (libsql), usato da tutti gli endpoint |
+| `src/lib/auth.ts` | Utility `timeSafeEqual()` e `verifyBearerToken()` per autenticazione admin |
+| `src/lib/email.ts` | Funzione `notifyNewComment()` per notifica email via Resend API |
+| `src/components/AdminNav.astro` | Navigazione condivisa nelle pagine admin |
+
+## Dipendenze
+
+| Libreria | Uso |
+| -------- | --- |
+| `@libsql/client` | Client per Turso (SQLite edge DB) |
+| `astro` (framework) | Routing, SSR, componenti, `APIRoute` type |
+| Resend API (HTTP) | Invio email di notifica (nessun SDK, chiamata `fetch` diretta) |
+
+## Env vars
+
+| Variabile | Descrizione |
+| --------- | ----------- |
+| `TURSO_DATABASE_URL` | URL del database Turso |
+| `TURSO_AUTH_TOKEN` | Token di autenticazione per Turso |
+| `ADMIN_TOKEN` | Token segreto per accedere alle pagine e API admin |
+| `RESEND_API_KEY` | API key di Resend per l'invio email di notifica (opzionale: se assente le notifiche vengono silenziosamente saltate) |
+
+## Limiti e trade-off
+
+- **Nessun rate limiting**: gli endpoint pubblici non implementano throttling o rate limiting. Un bot potrebbe inviare molti commenti in poco tempo. Mitigazione parziale: honeypot field.
+- **Honeypot come unica difesa anti-spam**: non c'e CAPTCHA ne altri meccanismi avanzati. L'honeypot funziona contro bot semplici ma non contro attacchi mirati.
+- **Moderazione solo manuale**: ogni commento richiede approvazione manuale dell'admin. Non c'e moderazione automatica, filtri per parole chiave o integrazione con servizi anti-spam.
+- **Nessuna paginazione**: le query non implementano LIMIT/OFFSET. Su pagine con molti commenti, tutte le righe vengono caricate in una sola richiesta.
+- **Email non visibile pubblicamente**: la GET pubblica non espone l'email, ma questa viene comunque raccolta e salvata nel DB. Non c'e un meccanismo di opt-in esplicito ne informativa sulla privacy inline.
+- **Token admin nel query string**: la pagina admin usa il token come query parameter (`?token=...`), il che lo espone nei log del server e nella cronologia del browser. Mitigato dal meta tag `referrer: no-referrer`.
+- **Label i18n duplicate**: le traduzioni del componente `Comments.astro` sono definite sia nel frontmatter (per SSR) che nello script inline (per il client), creando duplicazione. Questo e necessario perche `<script is:inline>` non ha accesso alle variabili Astro.
+- **Nessuna notifica di risposta**: l'utente che commenta non riceve notifica quando il suo commento viene approvato o quando qualcuno risponde.
+- **Commenti piatti**: non esiste una struttura a thread/risposte. Tutti i commenti sono allo stesso livello, ordinati cronologicamente.
+- **Nessun editing/cancellazione da parte dell'utente**: una volta inviato, il commento puo essere gestito solo dall'admin.
+
+### Possibili evoluzioni
+
+- Aggiungere rate limiting (es. per IP o fingerprint)
+- Implementare paginazione lato API e UI
+- Aggiungere notifiche email per i commentatori
+- Supportare commenti annidati (thread)
+- Integrare un sistema anti-spam piu robusto (es. Akismet)
+- Spostare l'autenticazione admin su cookie HttpOnly invece che query string

--- a/docs/contact-spec.md
+++ b/docs/contact-spec.md
@@ -1,0 +1,145 @@
+# Contact Form — Spec
+
+## Obiettivo
+
+Permettere ai visitatori di inviare un messaggio al proprietario del sito tramite un modulo contatti. Il messaggio viene inoltrato via email (Resend API) senza salvarlo in database. Il sistema include protezioni anti-spam (honeypot) e rate limiting.
+
+## Architettura
+
+```
+  Browser (client)                    Netlify Function                  Resend API
+       |                                    |                              |
+  [Form submit]                             |                              |
+       |                                    |                              |
+  JS intercetta submit                      |                              |
+  raccoglie campi + honeypot                |                              |
+       |                                    |                              |
+  POST /api/contact  ------------------>  [Validazione]                    |
+  Content-Type: application/json            |                              |
+                                     1. Check Origin                       |
+                                        (CORS whitelist)                   |
+                                            |                              |
+                                     2. Rate Limit                         |
+                                        (3 req/min per IP)                 |
+                                            |                              |
+                                     3. Honeypot                           |
+                                        (campo "website" pieno = bot)      |
+                                        risponde 200 ok (silent discard)   |
+                                            |                              |
+                                     4. Validazione campi                  |
+                                        name <= 100 char                   |
+                                        email <= 254 char + regex          |
+                                        message <= 5000 char               |
+                                            |                              |
+                                     5. sendContactEmail() ----------> POST /emails
+                                        via Resend API                     |
+                                            |                         Email a
+                                            |                         valerio.narcisi@gmail.com
+                                     6. Risposta al client                 |
+                                        { ok: true } | { error: "..." }   |
+       |                                    |                              |
+  [Mostra feedback]  <------------------    |                              |
+  successo / errore                         |                              |
+```
+
+## Dati / Schema
+
+### Payload richiesta (`POST /api/contact`)
+
+```json
+{
+  "name": "string",       // obbligatorio, max 100 caratteri
+  "email": "string",      // obbligatorio, max 254 caratteri, validato con regex
+  "message": "string",    // obbligatorio, max 5000 caratteri
+  "website": "string"     // honeypot: se compilato, la richiesta viene scartata silenziosamente
+}
+```
+
+### Risposta
+
+| Status | Body | Significato |
+|--------|------|-------------|
+| 200 | `{ "ok": true }` | Messaggio inviato (o honeypot attivato — stessa risposta) |
+| 400 | `{ "error": "..." }` | JSON invalido o campi mancanti/invalidi |
+| 403 | `{ "error": "Forbidden" }` | Origin non nell'allowlist |
+| 429 | `{ "error": "Too many requests" }` | Rate limit superato |
+| 500 | `{ "error": "Failed to send" }` | Errore invio email via Resend |
+
+### Email generata
+
+- **Da**: `Blog <onboarding@resend.dev>` (dominio sandbox Resend)
+- **A**: `valerio.narcisi@gmail.com` (hardcoded)
+- **Reply-To**: email del mittente (per rispondere direttamente)
+- **Oggetto**: `Nuovo messaggio da {nome}`
+- **Corpo**: HTML con nome, email e messaggio (escape HTML applicato)
+
+## API Endpoints
+
+### `POST /api/contact`
+
+Endpoint serverless (Netlify Function, `prerender = false`).
+
+**Sicurezza**:
+- **CORS Origin check**: accetta solo richieste da `valerionarcisi.me`, `www.valerionarcisi.me`, `localhost:4321`, `localhost:3000`
+- **Rate limiting**: massimo 3 richieste per IP in una finestra di 60 secondi. Implementato con `Map` in-memory (si resetta al cold start della function)
+- **Honeypot**: campo nascosto `website` — se compilato, il server risponde `200 { ok: true }` senza inviare email (i bot non si accorgono del rifiuto)
+- **Validazione input**: tipo, lunghezza e formato email verificati server-side
+- **Escape HTML**: tutti i campi vengono sanitizzati con `escapeHtml()` prima di inserirli nell'email
+
+## Componenti UI
+
+### Pagina `contatti.astro`
+
+Pagina statica con layout basato su `BlogPost.css`. Contiene:
+
+- Testo introduttivo in italiano
+- Form HTML con 3 campi visibili: Nome (`text`, `maxlength=100`), Email (`email`, `maxlength=254`), Messaggio (`textarea`, `maxlength=5000`)
+- Campo honeypot nascosto (`website`) con `aria-hidden="true"` e `tabindex="-1"`
+- Pulsante "Invia"
+- Div `#form-result` con `aria-live="polite"` per feedback accessibile
+
+**Script inline** (`is:inline`):
+- Intercetta il submit del form
+- Disabilita il pulsante e mostra "Invio in corso..."
+- Invia i dati come JSON a `/api/contact`
+- Mostra messaggio di successo ("Messaggio inviato!") o errore
+- Resetta il form dopo invio riuscito
+- Riabilita il pulsante in ogni caso (`finally`)
+
+## i18n
+
+La pagina contatti esiste solo in italiano (`/contatti`). Non c'e una versione inglese. Tutti i testi (label, messaggi di feedback, placeholder) sono hardcoded in italiano direttamente nel template e nello script.
+
+## File coinvolti
+
+| File | Ruolo |
+|------|-------|
+| `src/pages/contatti.astro` | Pagina contatti (IT) con form e script client |
+| `src/pages/api/contact.ts` | Endpoint serverless — validazione, rate limit, invio email |
+| `src/lib/email.ts` | Utility invio email via Resend (`sendContactEmail()`) |
+| `src/components/ContactForm.css` | Stili del form (importato nella pagina) |
+| `src/components/BaseHead.astro` | Head HTML (SEO, meta) |
+| `src/components/Header.astro` | Header navigazione |
+| `src/components/Footer.astro` | Footer |
+
+## Dipendenze
+
+- **Resend API** — servizio email transazionale (HTTP REST, nessun SDK installato)
+- **Netlify Functions** — runtime serverless per l'endpoint `/api/contact`
+- **Nessun database** — i messaggi non vengono salvati, solo inoltrati via email
+
+## Env vars
+
+| Variabile | Obbligatoria | Descrizione |
+|-----------|-------------|-------------|
+| `RESEND_API_KEY` | si | API key per il servizio Resend. Se assente, `sendContactEmail()` ritorna `false` |
+
+## Limiti e trade-off
+
+- **Rate limiting in-memory**: il `Map` che traccia le richieste per IP vive nella memoria della funzione serverless. Si resetta ad ogni cold start di Netlify Functions, quindi non e persistente. Un attaccante potrebbe aggirarlo forzando nuove istanze.
+- **Nessun CAPTCHA**: la protezione anti-bot si basa unicamente sull'honeypot. Bot sofisticati che analizzano il DOM potrebbero evitare il campo nascosto.
+- **Nessun salvataggio dei messaggi**: se l'email non viene recapitata (errore Resend, quota esaurita, ecc.), il messaggio e perso. Non esiste coda di retry.
+- **Dominio sandbox Resend**: il mittente e `onboarding@resend.dev` (dominio sandbox), il che potrebbe causare problemi di deliverability o finire in spam. Per produzione sarebbe meglio un dominio verificato.
+- **Solo italiano**: la pagina contatti non ha una versione inglese. I visitatori anglofoni del sito (che navigano su `/en/`) non hanno un modulo contatti localizzato.
+- **Validazione email basilare**: la regex `^[^\s@]+@[^\s@]+\.[^\s@]+$` copre i casi comuni ma non e conforme a RFC 5322. Sufficiente per uso pratico.
+- **Nessuna conferma al mittente**: chi invia il messaggio non riceve email di conferma, solo il feedback visivo nella pagina.

--- a/docs/lastfm-spec.md
+++ b/docs/lastfm-spec.md
@@ -1,0 +1,166 @@
+# Last.FM — Spec
+
+## Obiettivo
+
+Mostrare nella homepage i brani ascoltati di recente dall'utente Last.FM `valerionar`, con copertina album, artista e data di ascolto. I dati vengono recuperati a runtime tramite un endpoint serverless e renderizzati come card orizzontali scrollabili (componente condiviso con Letterboxd).
+
+## Architettura
+
+```
+Browser (client)
+     |
+     | GET /api/lastfm
+     v
++-----------------------------+
+| API Endpoint (Netlify fn)   |
+|  lastfm.ts                  |
++-----------------------------+
+     |
+     | fetch user.getrecenttracks
+     | (limit=20)
+     v
++-----------------------------+
+| Audioscrobbler API v2.0     |
+| ws.audioscrobbler.com       |
++-----------------------------+
+     |
+     | JSON (recent tracks)
+     v
++-----------------------------+
+| Filtraggio:                 |
+| - escludi tracce senza album|
+| - escludi placeholder image |
++-----------------------------+
+     |
+     | JSON array
+     v
++-----------------------------+
+| Reel.astro (componente UI) |
+| card con cover, artista,    |
+| album, data                 |
++-----------------------------+
+```
+
+## Dati
+
+### Dati dall'API Audioscrobbler
+
+| Campo              | Origine              | Descrizione                          |
+| ------------------ | -------------------- | ------------------------------------ |
+| `name`             | track                | Nome del brano                       |
+| `url`              | track                | URL della pagina Last.FM del brano   |
+| `artist.#text`     | track.artist         | Nome dell'artista                    |
+| `album.#text`      | track.album          | Nome dell'album                      |
+| `image[].#text`    | track.image          | URL copertina (array per dimensione) |
+| `date.#text`       | track.date           | Data/ora scrobble (assente se in riproduzione) |
+
+### Schema Zod (service layer)
+
+Il service `audioscrobbler.ts` definisce uno schema Zod per validare la risposta API:
+
+```ts
+Track {
+  name: string
+  url: string
+  date?: { "#text": string }
+  album: { "#text": string }
+  artist: { "#text": string }
+  image: Array<{ "#text": string, size: string }>
+}
+```
+
+### Oggetto restituito al client (endpoint)
+
+```ts
+{
+  name: string;    // nome brano
+  url: string;     // URL pagina Last.FM
+  artist: string;  // nome artista
+  album: string;   // nome album
+  image: string;   // URL copertina (dimensione "extralarge", indice 3)
+  date: string | null;  // data scrobble (null se in riproduzione)
+}
+```
+
+## API Endpoints
+
+### `GET /api/lastfm`
+
+- **Prerender**: `false` (serverless, eseguito a runtime)
+- **Autenticazione**: nessuna (endpoint pubblico)
+- **Cache**: `Cache-Control: public, max-age=900` (15 minuti)
+- **Parametri API**: `method=user.getrecenttracks`, `user=valerionar`, `limit=20`, `format=json`
+- **Flusso**:
+  1. Costruisce query params per l'API Audioscrobbler
+  2. Fetch `https://ws.audioscrobbler.com/2.0/`
+  3. Filtra tracce: escludi quelle senza album e con immagine placeholder
+  4. Mappa i campi nel formato semplificato
+  5. Restituisce array JSON
+- **Filtri applicati**:
+  - `album["#text"] !== ""` — rimuove tracce senza album associato
+  - `image[0]["#text"] !== PLACEHOLDER_IMAGE` — rimuove tracce con immagine placeholder Last.FM generica
+- **Risposte di errore**:
+  - `502` se il fetch verso Audioscrobbler fallisce
+  - `500` per errori interni generici
+
+## Componenti UI
+
+### `Reel.astro` (tipo `"song"`)
+
+Il componente Reel e' condiviso con il flusso Letterboxd. In modalita' `song`:
+
+**Props specifiche**:
+
+| Prop         | Tipo   | Descrizione                 |
+| ------------ | ------ | --------------------------- |
+| `url`        | string | URL copertina album         |
+| `href`       | string | Link esterno (Last.FM)      |
+| `title`      | string | Nome del brano              |
+| `watchedDate`| string | Data scrobble               |
+| `artist`     | string | Nome artista                |
+| `album`      | string | Nome album                  |
+| `type`       | `"song"` | Attiva layout quadrato    |
+
+**Differenze rispetto a `movie`**:
+- Thumbnail quadrata (160x160 mobile, 185x160 desktop) invece che verticale
+- Placeholder SVG diverso ("No Cover" invece di "No Poster")
+- Mostra artista (colore accent cyan, font mono) e album (corsivo) sotto il titolo
+- Nessun badge voto
+
+## File coinvolti
+
+| File | Ruolo |
+| --- | --- |
+| `src/pages/api/lastfm.ts` | Endpoint serverless — fetch Audioscrobbler, filtra, ritorna JSON |
+| `src/services/audioscrobbler.ts` | Service layer — schema Zod, tipo `AudioScubblerTrack`, funzione `fetchRecentTracks()` |
+| `src/components/Reel.astro` | Componente card (condiviso con Letterboxd) |
+| `src/components/Reel.css` | Stili co-locati del componente Reel |
+
+**Nota**: come per Letterboxd, l'endpoint `api/lastfm.ts` reimplementa la logica di fetch e filtraggio inline, invece di importare `fetchRecentTracks()` dal service. Il service offre in piu' la validazione Zod.
+
+## Dipendenze
+
+| Pacchetto | Utilizzo |
+| --- | --- |
+| `astro` | Framework, routing, endpoint serverless |
+| `astro:content` (zod) | Validazione schema nel service layer |
+
+Nessuna dipendenza esterna aggiuntiva (a differenza di Letterboxd che richiede `xml2js`). L'API Audioscrobbler restituisce JSON direttamente.
+
+## Env vars
+
+| Variabile | Obbligatoria | Descrizione |
+| --- | --- | --- |
+| `LASTFM_API_KEY` | Si | API key per Last.FM / Audioscrobbler |
+
+## Limiti e trade-off
+
+- **Nessuna cache persistente**: come per Letterboxd, i dati vengono recuperati ad ogni richiesta (mitigato dal `max-age=900` HTTP).
+- **Duplicazione logica**: l'endpoint `api/lastfm.ts` non utilizza il service `audioscrobbler.ts` che offre validazione Zod e tipizzazione. La logica di fetch e filtraggio e' duplicata.
+- **Nessuna validazione nell'endpoint**: a differenza del service (che usa Zod), l'endpoint accede ai dati con `any` senza validazione.
+- **Utente hardcoded**: `valerionar` e' hardcoded sia nell'endpoint che nel service.
+- **Limite fisso a 20 tracce**: il parametro `limit=20` e' hardcoded. Non e' configurabile dal client.
+- **Traccia in riproduzione**: se l'utente sta ascoltando un brano, `date` sara' `null` (il campo `date` e' assente nella risposta API per la traccia "now playing").
+- **Immagine extralarge**: l'endpoint usa l'indice `[3]` dell'array immagini (dimensione "extralarge", ~300px). Non c'e' fallback se l'array ha meno di 4 elementi.
+- **Filtro placeholder fragile**: l'URL dell'immagine placeholder Last.FM e' hardcoded. Se Last.FM cambia l'URL, il filtro smettera' di funzionare.
+- **Typo nel service**: il tipo si chiama `AudioScubblerSchema` / `AudioScubblerResponse` (manca una "r" in "Scrobbler"). Impatto solo estetico, non funzionale.

--- a/docs/letterboxd-spec.md
+++ b/docs/letterboxd-spec.md
@@ -1,0 +1,154 @@
+# Letterboxd / TMDB — Spec
+
+## Obiettivo
+
+Mostrare nella homepage i film visti di recente dall'utente Letterboxd `valenar`, arricchiti con poster e valutazione media da TMDB. I dati vengono recuperati a runtime tramite un endpoint serverless e renderizzati come card orizzontali scrollabili.
+
+## Architettura
+
+```
+Browser (client)
+     |
+     | GET /api/letterboxd
+     v
++-----------------------------+
+| API Endpoint (Netlify fn)   |
+|  letterboxd.ts              |
++-----------------------------+
+     |                    |
+     | 1. fetch RSS       | 2. per ogni film con tmdb:movieId
+     v                    v
++-----------------+   +-------------------+
+| Letterboxd RSS  |   | TMDB API v3       |
+| /valenar/rss/   |   | /movie/{id}       |
++-----------------+   +-------------------+
+     |                    |
+     | XML (RSS 2.0)      | JSON (dettagli film)
+     v                    v
++-----------------------------+
+| Parsing + merge dati       |
+| title, posterPath,          |
+| voteAverage, link,          |
+| watchedDate                 |
++-----------------------------+
+     |
+     | JSON array
+     v
++-----------------------------+
+| Reel.astro (componente UI) |
+| card con poster, voto, data |
++-----------------------------+
+```
+
+## Dati
+
+### Dati estratti dal feed RSS Letterboxd
+
+| Campo                       | Origine            | Descrizione                        |
+| --------------------------- | ------------------ | ---------------------------------- |
+| `letterboxd:filmTitle`      | RSS item           | Titolo del film su Letterboxd      |
+| `tmdb:movieId`              | RSS item           | ID TMDB (usato come chiave join)   |
+| `letterboxd:watchedDate`    | RSS item           | Data di visione (YYYY-MM-DD)       |
+| `link`                      | RSS item           | URL della review su Letterboxd     |
+
+### Dati arricchiti da TMDB
+
+| Campo          | Origine       | Descrizione                              |
+| -------------- | ------------- | ---------------------------------------- |
+| `poster_path`  | TMDB API      | Path relativo del poster (w500)          |
+| `vote_average` | TMDB API      | Voto medio della community TMDB          |
+| `vote_count`   | TMDB API      | Numero totale di voti                    |
+| `title`        | TMDB API      | Titolo (fallback se manca dal RSS)       |
+
+### Oggetto restituito al client
+
+```ts
+{
+  title: string;         // titolo film (RSS, fallback TMDB)
+  posterPath: string;    // path poster TMDB (es. "/abc123.jpg")
+  voteAverage: number;   // media voti TMDB
+  voteCount: number;     // conteggio voti TMDB
+  link: string;          // URL review Letterboxd
+  watchedDate: string;   // data visione (YYYY-MM-DD)
+}
+```
+
+## API Endpoints
+
+### `GET /api/letterboxd`
+
+- **Prerender**: `false` (serverless, eseguito a runtime)
+- **Autenticazione**: nessuna (endpoint pubblico)
+- **Cache**: `Cache-Control: public, max-age=900` (15 minuti)
+- **Flusso**:
+  1. Fetch RSS da `https://letterboxd.com/valenar/rss/`
+  2. Parsing XML con `xml2js.parseString`
+  3. Filtra solo gli item con `tmdb:movieId` presente
+  4. Per ogni item, chiama TMDB API v3 `/movie/{id}` in parallelo (`Promise.all`)
+  5. Merge dati RSS + TMDB, scarta eventuali film falliti (`null`)
+  6. Restituisce array JSON
+- **Risposte di errore**:
+  - `502` se il fetch RSS fallisce
+  - `500` per errori interni generici
+
+## Componenti UI
+
+### `Reel.astro`
+
+Componente riutilizzabile per card di film e brani musicali in uno scroll orizzontale.
+
+**Props** (tipo `movie`):
+
+| Prop           | Tipo     | Descrizione                        |
+| -------------- | -------- | ---------------------------------- |
+| `url`          | string   | URL completa immagine poster       |
+| `href`         | string   | Link esterno (Letterboxd)          |
+| `title`        | string   | Titolo del film                    |
+| `watchedDate`  | string   | Data visione                       |
+| `vote_average` | number?  | Voto medio TMDB                    |
+| `vote_count`   | number?  | Conteggio voti TMDB                |
+| `type`         | `"movie" \| "song"` | Determina layout della card |
+
+**Comportamento**:
+- Poster con dimensione fissa (160x240 mobile, 185x278 desktop)
+- Badge voto sovrapposto in alto a destra (font mono, sfondo semi-trasparente con blur)
+- Placeholder SVG se il poster manca o fallisce il caricamento (`onerror` inline)
+- Data formattata in formato breve inglese (es. "Mar 15")
+- Titolo troncato a 2 righe con `-webkit-line-clamp`
+- Hover: zoom 1.05 + brightness 1.1 sul poster
+
+## File coinvolti
+
+| File | Ruolo |
+| --- | --- |
+| `src/pages/api/letterboxd.ts` | Endpoint serverless — fetch RSS, join TMDB, ritorna JSON |
+| `src/services/letterboxd.ts` | Service layer — `getLetterboxdRss()` e `parseXmlContent()` (utility riusabili) |
+| `src/services/tmdb.ts` | Service layer — `getMovieById()`, costanti API TMDB |
+| `src/components/Reel.astro` | Componente card (condiviso con Last.FM) |
+| `src/components/Reel.css` | Stili co-locati del componente Reel |
+
+**Nota**: l'endpoint `api/letterboxd.ts` attualmente duplica parte della logica presente nei service (`letterboxd.ts`, `tmdb.ts`) invece di importarli direttamente. I service sono disponibili per un eventuale refactoring.
+
+## Dipendenze
+
+| Pacchetto | Versione | Utilizzo |
+| --- | --- | --- |
+| `xml2js` | — | Parsing XML del feed RSS Letterboxd |
+| `astro` | 5.x | Framework, routing, endpoint serverless |
+
+## Env vars
+
+| Variabile | Obbligatoria | Descrizione |
+| --- | --- | --- |
+| `TMDB_API_KEY` | Si | API key per The Movie Database (v3) |
+
+## Limiti e trade-off
+
+- **Nessuna cache persistente**: i dati vengono recuperati ad ogni richiesta (mitigato dal `max-age=900` HTTP). Non c'e' un layer di cache server-side (Redis, KV store, ecc.).
+- **Rate limiting TMDB**: ogni chiamata all'endpoint genera N richieste parallele a TMDB (una per film nel feed RSS). Con feed lunghi si rischia di superare i rate limit TMDB.
+- **Chiamate N+1**: il pattern e' 1 fetch RSS + N fetch TMDB. Non c'e' batching (TMDB non offre un endpoint bulk per ID multipli).
+- **Duplicazione logica**: l'endpoint `api/letterboxd.ts` reimplementa parsing XML e fetch TMDB inline, invece di riusare `src/services/letterboxd.ts` e `src/services/tmdb.ts`.
+- **Nessuna validazione schema**: la risposta TMDB e il feed RSS non vengono validati con Zod o simili; si usa `any` per il parsing.
+- **Utente hardcoded**: il profilo Letterboxd `valenar` e' hardcoded sia nell'endpoint che nel service.
+- **Nessun limite item**: tutti gli item del feed RSS con `tmdb:movieId` vengono processati. Il feed Letterboxd puo' contenere decine di entry.
+- **Immagini TMDB w500**: il poster viene servito in formato `w500` (via costante `IMAGES_URL` nel service), adeguato per le dimensioni della card ma potenzialmente sovradimensionato per mobile.

--- a/docs/meal-plan-spec.md
+++ b/docs/meal-plan-spec.md
@@ -1,0 +1,120 @@
+# Meal Plan — Spec
+
+## Obiettivo
+
+Dashboard admin privata che mostra il piano alimentare settimanale completo (colazione, pranzo, cena e spuntini) con navigazione a tab per giorno della settimana. Pensata per consultazione rapida da mobile durante la spesa o in cucina.
+
+## Architettura
+
+```
+┌─────────────────────────────────────────────────┐
+│                   Browser                        │
+│  GET /admin/meal-plan?token=ADMIN_TOKEN          │
+└──────────────────────┬──────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────┐
+│         Astro SSR (Netlify Function)             │
+│                                                  │
+│  1. Verifica token via timeSafeEqual()           │
+│  2. Importa days[] e snacks[] da meal-plan.ts    │
+│  3. Renderizza HTML statico con tutti i giorni   │
+│  4. Inietta <script is:inline> per tab switching │
+└──────────────────────┬──────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────┐
+│              src/data/meal-plan.ts                │
+│                                                  │
+│  Dati hardcoded: DayPlan[] + SnackSection[]      │
+│  Nessuna API esterna, nessun DB                  │
+└─────────────────────────────────────────────────┘
+```
+
+## Dati / Schema
+
+### `DayPlan`
+
+```typescript
+interface MealOption {
+  items: string[];   // alimenti con grammature
+  oil?: string;      // indicazione olio EVO (es. "3 cucchiaini olio EVO a crudo")
+}
+
+interface Meal {
+  name: string;      // "Colazione" | "Pranzo" | "Cena" | "Cena (libera)" | "Spuntino"
+  options: MealOption[];  // options[0] = principale, options[1..n] = alternative
+}
+
+interface DayPlan {
+  id: string;        // "lun" | "mar" | "mer" | "gio" | "ven" | "sab" | "dom"
+  label: string;     // "Lunedi", "Martedi", ...
+  short: string;     // "Lun", "Mar", ...
+  meals: Meal[];     // tipicamente 3 pasti (colazione, pranzo, cena), domenica ne ha 4
+}
+```
+
+### `SnackSection`
+
+```typescript
+interface SnackSection {
+  name: string;        // "Pre-Allenamento" | "Mattino Post-Allenamento" | "Mattino (no allenamento)" | "Pomeriggio"
+  options: string[][]; // ogni opzione e un array di stringhe (alimenti combinabili con "+")
+}
+```
+
+### Struttura dati
+
+- **7 giorni** (lun-dom), ognuno con 3-4 pasti
+- Ogni pasto ha 1-3 opzioni (la prima e quella principale)
+- **4 sezioni spuntini** separate dai giorni, con 3-11 opzioni ciascuna
+- La domenica ha una struttura speciale: colazione libera, pranzo con 3 opzioni, spuntino dedicato, cena libera (pizza o ristorante)
+
+## Componenti UI
+
+| Componente | Descrizione |
+|---|---|
+| **Tab bar** | Barra orizzontale scrollabile con 8 bottoni (Lun-Dom + Spuntini). Seleziona automaticamente il giorno corrente al caricamento |
+| **Meal card** | Card scura con header (emoji + nome pasto), badge olio (verde/rosso), lista alimenti |
+| **Alternative** | Blocco `<details>` espandibile ("1 alternativa" / "N alternative") con opzioni aggiuntive |
+| **Oil badge** | Badge colorato: verde se presente olio, rosso se contiene "no" (classe `.no-oil`) |
+| **Snack section** | Card con opzioni numerate, unite con " + " per alimenti combinabili |
+| **AdminNav** | Navigazione admin condivisa (componente esterno) |
+
+### Interazione client-side
+
+- Script inline (non framework) che mappa `new Date().getDay()` -> id giorno (`dayMap[]`)
+- Tab switching via `selectTab(id)`: toggle classi `.active` su tab e panel
+- Attributi ARIA: `role="tablist"`, `role="tab"`, `role="tabpanel"`, `aria-selected`
+
+## File coinvolti
+
+| File | Ruolo |
+|---|---|
+| `src/pages/admin/meal-plan.astro` | Pagina SSR, layout, stili, logica tab |
+| `src/data/meal-plan.ts` | Dati del piano alimentare (export `days`, `snacks`) |
+| `src/components/AdminNav.astro` | Navigazione admin condivisa |
+| `src/lib/auth.ts` | Funzione `timeSafeEqual()` per verifica token |
+
+## Dipendenze
+
+- **Astro 5** — framework SSR
+- **Nessuna dipendenza esterna** per i dati (tutto hardcoded in TypeScript)
+- **Nessuna libreria JS client-side** (vanilla JS inline)
+- **Nessun database**
+
+## Env vars
+
+| Variabile | Uso |
+|---|---|
+| `ADMIN_TOKEN` | Token segreto per autenticazione. Passato come query parameter `?token=` |
+
+## Limiti e trade-off
+
+- **Dati hardcoded**: il piano alimentare e scritto direttamente in `meal-plan.ts`. Per aggiornare i pasti bisogna modificare il file e rifare il deploy. Non esiste un'interfaccia di editing.
+- **Nessun database**: scelta deliberata per semplicita — il piano cambia raramente e non richiede CRUD.
+- **Autenticazione via query parameter**: il token e visibile nell'URL e nei log del server. Sufficiente per uso personale, non adatto a contesti multi-utente.
+- **Nessun supporto i18n**: la pagina e solo in italiano (il piano alimentare e personale).
+- **`prerender = false`**: la pagina e renderizzata server-side ad ogni richiesta (Netlify Function) per verificare il token. Non e cacheable.
+- **Emoji hardcoded**: la mappa `mealEmoji` associa emoji ai nomi dei pasti. Se il nome del pasto cambia nel data file, l'emoji non viene mostrata (fallback su generico).
+- **Mobile-first**: layout ottimizzato per consultazione su telefono (tab scrollabili, font ridotti sotto 500px).

--- a/docs/meditation-spec.md
+++ b/docs/meditation-spec.md
@@ -1,0 +1,245 @@
+# Meditation — Spec
+
+## Obiettivo
+
+Dashboard privata per il tracciamento della pratica di meditazione Vipassana. Serve a:
+
+- **Registrare sessioni** di meditazione con data, durata e tipo
+- **Visualizzare statistiche** (streak, sessioni totali, minuti totali, sessioni del mese)
+- **Guidare la pratica** con timer, guida vocale, sessioni strutturate e un percorso progressivo a fasi
+- **Motivare la costanza** tramite heatmap annuale, streak bar e citazioni giornaliere
+
+La pagina e' ad uso esclusivo dell'admin (autenticazione via token) e non e' indicizzata dai motori di ricerca.
+
+## Architettura
+
+```
+Browser (admin/meditation?token=XXX)
+  |
+  |  1. Astro SSR verifica token via query param
+  |     (timeSafeEqual vs ADMIN_TOKEN)
+  |
+  v
++---------------------+       +--------------------+
+| meditation.astro    |       | meditation-quotes  |
+| (pagina SSR)        |------>| .js (365 citazioni)|
+| - HTML/CSS/JS inline|       +--------------------+
++---------------------+
+  |
+  | 2. JS client-side: fetch() con Bearer token
+  |
+  v
++---------------------------+       +-----------------+
+| /api/admin/meditation.ts  |       | Turso (libsql)  |
+| GET  -> lista sessioni    |------>| meditation_     |
+| POST -> nuova sessione    |       | sessions        |
+| DELETE -> rimuovi sessione|       +-----------------+
++---------------------------+
+  |
+  | verifyBearerToken(req, ADMIN_TOKEN)
+  v
+  401 se non autorizzato
+```
+
+**Flusso dati:**
+1. La pagina Astro verifica il token nel query string (SSR) e serializza le 365 citazioni in JSON
+2. Il JS client chiama `GET /api/admin/meditation` per caricare le sessioni degli ultimi 365 giorni
+3. I dati vengono elaborati client-side: statistiche, heatmap, streak, percorso
+4. Al termine di una sessione timer, il JS chiama `POST /api/admin/meditation` per salvare automaticamente
+5. Tutto il rendering (stats, heatmap, journey, quote, focus, sessione) avviene client-side
+
+## Dati / Schema DB
+
+### Tabella `meditation_sessions`
+
+| Campo          | Tipo    | Vincoli / Default                        |
+|----------------|---------|------------------------------------------|
+| `id`           | INTEGER | PRIMARY KEY AUTOINCREMENT                |
+| `date`         | TEXT    | NOT NULL, formato `YYYY-MM-DD`           |
+| `duration_min` | INTEGER | DEFAULT 0                                |
+| `session_type` | TEXT    | Nullable, es. "Anapana — Consapevolezza del respiro" |
+| `created_at`   | TEXT    | `datetime('now')` al momento dell'INSERT |
+
+### Indici
+
+| Nome                    | Colonna | Scopo                                |
+|-------------------------|---------|--------------------------------------|
+| `idx_meditation_date`   | `date`  | Query efficiente per range di date   |
+
+La tabella viene creata automaticamente (`CREATE TABLE IF NOT EXISTS`) ad ogni richiesta API tramite `ensureTable()`.
+
+## API Endpoints
+
+### GET `/api/admin/meditation`
+
+| Aspetto        | Dettaglio                                                                 |
+|----------------|---------------------------------------------------------------------------|
+| Autenticazione | Bearer token nell'header `Authorization` (confrontato con `ADMIN_TOKEN`) |
+| Request body   | Nessuno                                                                   |
+| Query params   | Nessuno                                                                   |
+| Logica         | Seleziona tutte le sessioni con `date >= date('now', '-365 days')`, ordinate per data e id ASC |
+| Response 200   | `[{ id, date, duration_min, session_type, created_at }, ...]`            |
+| Response 401   | `"Unauthorized"` (testo piano)                                           |
+
+### POST `/api/admin/meditation`
+
+| Aspetto        | Dettaglio                                                                 |
+|----------------|---------------------------------------------------------------------------|
+| Autenticazione | Bearer token                                                              |
+| Request body   | `{ date: "YYYY-MM-DD", duration_min?: number, session_type?: string }`   |
+| Validazione    | `date` obbligatorio, deve corrispondere a `/^\d{4}-\d{2}-\d{2}$/`       |
+| Logica         | INSERT nella tabella con `created_at = datetime('now')`                  |
+| Response 201   | `{ ok: true, id: <number> }`                                             |
+| Response 400   | `{ error: "Valid date (YYYY-MM-DD) required" }`                          |
+| Response 401   | `"Unauthorized"`                                                          |
+
+### DELETE `/api/admin/meditation`
+
+| Aspetto        | Dettaglio                                                                 |
+|----------------|---------------------------------------------------------------------------|
+| Autenticazione | Bearer token                                                              |
+| Query params   | `id` (obbligatorio) — ID della sessione da eliminare                     |
+| Logica         | DELETE dalla tabella per ID                                               |
+| Response 200   | `{ ok: true }`                                                            |
+| Response 400   | `{ error: "id param required" }`                                         |
+| Response 401   | `"Unauthorized"`                                                          |
+
+## Componenti UI
+
+La pagina e' un singolo file `.astro` con CSS inline (`<style is:global>`) e JS inline (`<script is:inline>`). Non utilizza componenti Astro dedicati, ad eccezione di `AdminNav`.
+
+### Stats (griglia 4 colonne)
+
+Quattro box con statistiche calcolate client-side:
+- **Streak** — giorni consecutivi di pratica (conta da oggi o da ieri all'indietro)
+- **Sessioni** — totale sessioni (ultimi 365 giorni)
+- **Min totali** — somma di tutti i `duration_min`
+- **Questo mese** — numero sessioni del mese corrente
+
+### Heatmap (ultimi 365 giorni)
+
+Griglia in stile GitHub contributions: 7 righe (giorni della settimana) x ~52 colonne (settimane). Ogni cella rappresenta un giorno con colore in base ai minuti totali:
+- Vuoto: `#1a1a1e`
+- l1 (1-5 min): viola 25%
+- l2 (6-15 min): viola 45%
+- l3 (16-30 min): viola 70%
+- l4 (31+ min): `#bb86fc` pieno
+
+Il giorno corrente ha un bordo dorato. Cliccando su una cella si apre un pannello di dettaglio con l'elenco delle sessioni del giorno (tipo + durata) e il totale.
+
+### Journey / Fasi (percorso adattivo)
+
+Sistema a 8 fasi progressive su 24 mesi, ognuna con:
+- **Nome e icona** (Fondamenta, Corpo, Gentilezza, Visione, Profondita', Maturita', Integrazione, Maestria)
+- **Range di mesi** e durate consigliate (min/max)
+- **Pesi** per tipo di sessione (es. fase 1: 75% Anapana, 15% Body Scan, 10% Camminata)
+- **Testo spirituale** con insegnamenti Vipassana
+
+La fase corrente e' calcolata in base ai mesi di pratica effettivi, corretti per la consistenza (se la frequenza e' < 30%, i mesi vengono ridotti proporzionalmente). Una barra di progresso a 24 dot mostra l'avanzamento. La sessione giornaliera suggerita deriva dai pesi della fase corrente, indicizzata deterministicamente dal giorno dell'anno.
+
+### Timer
+
+Timer circolare SVG con anello di progresso e display digitale `MM:SS`.
+
+- **Preset**: 5, 10 (default), 15, 20, 30, 45 minuti
+- **Controlli**: Inizia/Pausa/Riprendi, Reset, Voce ON/OFF
+- **Breath label**: ciclo testuale di 4 fasi (Inspira, Trattieni, Espira, Pausa) ogni 2 secondi
+- **Guida attiva**: pannello che mostra lo step corrente della sessione con titolo, descrizione e hint
+- **Scheduling guidato**: gli step della sessione vengono distribuiti proporzionalmente sulla durata scelta, con transizioni annunciate da chime e voce
+- **Auto-save**: al termine del timer, la sessione viene salvata automaticamente via POST API
+- **Wake Lock**: richiede `navigator.wakeLock` per impedire lo spegnimento dello schermo durante la meditazione
+
+### Sessioni (7 tipi)
+
+Ogni tipo di sessione ha 4 step strutturati con titolo, descrizione e durata:
+
+1. **Anapana** — consapevolezza del respiro (triangolo narici-labbro)
+2. **Body Scan** — scansione delle sensazioni dalla testa ai piedi
+3. **Metta** — meditazione di amorevole gentilezza (se stessi, cari, tutti)
+4. **Vipassana profonda** — impermanenza, sensazioni sottili, equanimita'
+5. **Camminata consapevole** — movimento lento con micro-consapevolezza
+6. **Osservazione dei pensieri** — etichettare e lasciar andare
+7. **Suono e silenzio** — ascolto aperto e suono interno
+
+La sessione del giorno e' selezionata con `dayOfYear % sessions.length`, poi eventualmente sovrascritta dal sistema journey/fasi.
+
+### Citazione e focus giornalieri
+
+- **Citazione**: selezionata con `dayOfYear % 365` dall'array di 365 citazioni (autori: Goenka, Buddha, Thich Nhat Hanh, Rumi, Eckhart Tolle, tradizioni varie)
+- **Focus**: 2 card da un array di 7 coppie, ciclate per giorno della settimana. Ogni card ha icona, titolo e breve testo motivazionale
+
+### Audio System
+
+Suoni sintetizzati via Web Audio API (`AudioContext`), nessun file audio esterno:
+
+| Suono          | Frequenze      | Durata   | Uso                                  |
+|----------------|----------------|----------|--------------------------------------|
+| **Bell**       | 528 Hz + 396 Hz| 4 sec    | Inizio sessione (1x), fine (3x)     |
+| **Chime**      | 880 Hz         | 1.5 sec  | Transizione rapida                   |
+| **Low Chime**  | 440 Hz         | 1 sec    | Promemoria a meta' step             |
+| **Step Chimes**| 780 Hz         | 0.6 sec  | Transizione step (ripetuti N volte) |
+
+La campana tibetana e' simulata con due oscillatori sinusoidali sovrapposti e decay esponenziale del gain.
+
+### Voice System
+
+Utilizza la Web Speech Synthesis API (`SpeechSynthesis`) per la guida vocale in italiano:
+
+- **Voce**: cerca automaticamente una voce italiana (`lang.startsWith("it")`), fallback sulla voce di default. Retry fino a 10 volte con intervallo di 500ms
+- **Parametri**: `rate: 0.85`, `pitch: 0.9`, `lang: "it-IT"`
+- **Keep-alive**: workaround per bug Chrome che interrompe la sintesi dopo ~15s — `pause()/resume()` ogni 10 secondi
+- **Training mode**: dopo 30 giorni di pratica (`VOICE_TRAINING_DAYS`), la voce viene disattivata automaticamente (suggerimento a meditare in silenzio). L'utente puo' sovrascrivere via toggle (persistito in `localStorage`)
+- **Warm-up mobile**: su iOS/Android, la speech synthesis richiede un'utterance iniziale durante un user gesture, eseguita al click su "Inizia"
+
+## File coinvolti
+
+| File                                       | Azione     | Scopo                                              |
+|--------------------------------------------|------------|-----------------------------------------------------|
+| `src/pages/admin/meditation.astro`         | Esistente  | Pagina SSR con UI completa (HTML, CSS, JS inline)  |
+| `src/pages/api/admin/meditation.ts`        | Esistente  | API REST per CRUD sessioni di meditazione          |
+| `src/data/meditation-quotes.js`            | Esistente  | Array di 365 citazioni (text + author)             |
+| `src/components/AdminNav.astro`            | Esistente  | Navigazione admin condivisa                        |
+| `src/lib/turso.ts`                         | Esistente  | Client Turso (libsql) — `getDb()`                  |
+| `src/lib/auth.ts`                          | Esistente  | `verifyBearerToken()`, `timeSafeEqual()`           |
+
+## Dipendenze
+
+| Libreria / API         | Tipo       | Uso                                                   |
+|------------------------|------------|--------------------------------------------------------|
+| `@libsql/client`       | npm        | Client Turso per accesso al database SQLite edge      |
+| Web Audio API           | Browser    | Generazione suoni (campana, chime) via oscillatori    |
+| Web Speech Synthesis API| Browser    | Guida vocale in italiano durante la meditazione       |
+| Screen Wake Lock API    | Browser    | Previene lo spegnimento schermo durante il timer      |
+| `localStorage`          | Browser    | Persistenza preferenza voce ON/OFF (`meditation-voice-override`) |
+
+Nessuna libreria JS esterna lato client. Tutto il codice e' vanilla JS inline.
+
+## Env vars
+
+| Variabile            | Richiesta | Uso                                                     |
+|----------------------|-----------|---------------------------------------------------------|
+| `ADMIN_TOKEN`        | Si'       | Autenticazione pagina (query param) e API (Bearer token)|
+| `TURSO_DATABASE_URL` | Si'       | URL del database Turso                                  |
+| `TURSO_AUTH_TOKEN`   | Si'       | Token di autenticazione Turso                           |
+
+## Limiti e trade-off
+
+- **Single-user**: il sistema e' progettato per un solo utente (l'admin). Non c'e' gestione multi-utente
+- **Tutto inline**: CSS e JS sono inline nella pagina Astro. Vantaggio: zero richieste aggiuntive, deploy semplice. Svantaggio: file monolitico di ~1300 righe, non testabile unitariamente
+- **Nessun service worker**: se il browser va in background, il timer continua correttamente (usa `Date.now()` per il tempo reale, non `setInterval` cumulativo), ma l'audio/voce potrebbe non funzionare
+- **Audio sintetico**: i suoni sono generati via Web Audio API, non da file audio. La qualita' e' limitata ma evita il caricamento di asset esterni
+- **Speech Synthesis**: dipende dalle voci installate sul dispositivo. Se non c'e' una voce italiana, usa quella di default. Il workaround keep-alive per Chrome potrebbe non funzionare su tutti i browser
+- **Nessun export/backup**: i dati sono solo su Turso. Non c'e' funzionalita' di export CSV o backup
+- **DELETE non esposta nella UI**: l'endpoint DELETE esiste nell'API ma non c'e' un pulsante nella UI per cancellare sessioni
+- **Calcolo streak semplificato**: conta solo la presenza/assenza di sessioni per giorno, non la qualita' o la durata minima
+- **365 citazioni hardcoded**: le citazioni sono in un file JS statico, non nel database. Per aggiungerne o modificarne serve un deploy
+- **Nessuna notifica push**: non ci sono reminder per meditare. La motivazione e' affidata alla streak e all'abitudine
+
+### Possibili evoluzioni
+
+- Export dati in CSV/JSON
+- Statistiche avanzate (media durata, distribuzione per tipo, grafici temporali)
+- Reminder push via service worker / web notification
+- Separazione JS in moduli per testabilita'
+- Note personali per sessione
+- Pulsante delete nella UI per correggere sessioni errate

--- a/docs/strava-spec.md
+++ b/docs/strava-spec.md
@@ -1,0 +1,301 @@
+# Strava Integration — Spec
+
+## Obiettivo
+
+Mostrare sul sito le attivita sportive recenti dell'utente provenienti da Strava, con statistiche aggregate (settimanali e mensili), un grafico della corsa settimanale, una distribuzione per tipo di attivita e un breakdown giornaliero. I dati vengono recuperati a runtime tramite un endpoint API serverless (Netlify) che interroga le API Strava v3.
+
+## Architettura
+
+```
+┌──────────────┐       ┌──────────────────┐       ┌──────────────┐
+│  Browser     │──GET──▶ /api/strava       │──────▶│ Strava OAuth │
+│  (client JS) │       │ (Netlify fn,     │       │ Token URL    │
+│              │◀─JSON─│  prerender:false) │       └──────┬───────┘
+└──────────────┘       │                  │              │
+                       │  services/       │◀─────────────┘
+                       │  strava.ts       │  access_token
+                       │                  │
+                       │                  │──GET──▶ Strava API v3
+                       │                  │         /athlete/activities
+                       │                  │◀─JSON──
+                       └──────────────────┘
+                              │
+                  Formatta + aggrega dati
+                              │
+                              ▼
+                       JSON response
+                       {activities, stats,
+                        dailyBreakdown,
+                        yearlyBreakdown,
+                        typeDistribution,
+                        weeklyRunStats}
+```
+
+**Flusso:**
+
+1. Il client chiama `GET /api/strava`.
+2. L'endpoint effettua in parallelo due chiamate al service layer:
+   - `fetchRecentActivities(5)` — ultime 5 attivita.
+   - `fetchFullStats()` — tutte le attivita dell'ultimo anno (paginazione automatica a blocchi di 200).
+3. Il service ottiene un `access_token` fresco tramite OAuth2 refresh token grant.
+4. I dati grezzi vengono normalizzati, aggregati e formattati.
+5. La risposta JSON viene restituita con `Cache-Control: public, max-age=900` (15 minuti).
+
+## Dati
+
+### Interfacce principali (definite in `services/strava.ts`)
+
+**`StravaActivity`** — Risposta grezza dell'API Strava:
+
+| Campo               | Tipo     | Note                          |
+|---------------------|----------|-------------------------------|
+| id                  | number   | ID univoco attivita           |
+| name                | string   | Nome attivita                 |
+| type                | string   | Tipo generico (Run, Ride...)  |
+| sport_type          | string   | Tipo specifico (TrailRun...)  |
+| start_date          | string   | ISO 8601                      |
+| distance            | number   | Metri                         |
+| moving_time         | number   | Secondi                       |
+| elapsed_time        | number   | Secondi (incluse pause)       |
+| total_elevation_gain| number   | Metri                         |
+| average_speed       | number   | m/s                           |
+| max_speed           | number   | m/s                           |
+| average_heartrate   | number?  | bpm (opzionale)               |
+| max_heartrate       | number?  | bpm (opzionale)               |
+| suffer_score        | number?  | Indice di sforzo (opzionale)  |
+| kudos_count         | number   | Numero di kudos               |
+
+**`NormalizedActivity`** — Versione normalizzata (camelCase, campi ridotti):
+
+| Campo            | Tipo     | Note                              |
+|------------------|----------|-----------------------------------|
+| id               | number   |                                   |
+| name             | string   |                                   |
+| type             | string   |                                   |
+| sportType        | string   |                                   |
+| date             | string   | ISO 8601                          |
+| distance         | number   | Metri                             |
+| movingTime       | number   | Secondi                           |
+| elevation        | number   | Metri                             |
+| averageSpeed     | number   | m/s                               |
+| averageHeartrate | number?  | bpm                               |
+| kudos            | number   |                                   |
+| url              | string   | Link diretto a strava.com         |
+
+**`ActivityStats`** — Statistiche aggregate per un periodo:
+
+| Campo            | Tipo   | Note                             |
+|------------------|--------|----------------------------------|
+| totalActivities  | number | Conteggio attivita               |
+| totalDistance     | number | Metri                            |
+| totalElevation   | number | Metri                            |
+| totalMovingTime  | number | Secondi                          |
+| averagePace      | number | Secondi per km (media ponderata) |
+
+**`DailyBreakdown`** — Dettaglio giornaliero (ultimi 30 o 365 giorni):
+
+| Campo      | Tipo             | Note                                    |
+|------------|------------------|-----------------------------------------|
+| date       | string           | YYYY-MM-DD                              |
+| distance   | number           | Metri totali del giorno                 |
+| duration   | number           | Secondi totali del giorno               |
+| type       | string           | Sport type dell'attivita principale     |
+| color      | string           | Colore associato al tipo                |
+| activities | DailyActivity[]  | Lista di tutte le attivita del giorno   |
+
+**`TypeDistribution`** — Distribuzione per tipo di sport (ultimo mese):
+
+| Campo         | Tipo   | Note                          |
+|---------------|--------|-------------------------------|
+| type          | string | sport_type                    |
+| label         | string | Etichetta leggibile           |
+| color         | string | Colore hex                    |
+| totalDistance  | number | Metri                         |
+| totalDuration | number | Secondi                       |
+| count         | number | Numero attivita               |
+| percentage    | number | Percentuale sul totale (0-100)|
+
+**`WeeklyRunStats`** — Statistiche settimanali di corsa (ultime 8 settimane):
+
+| Campo     | Tipo   | Note                         |
+|-----------|--------|------------------------------|
+| weekLabel | string | Es. "3-9/2" o "28/1-3/2"    |
+| weekStart | string | YYYY-MM-DD                   |
+| distance  | number | Metri                        |
+| pace      | number | Secondi per km               |
+| runs      | number | Numero corse                 |
+| elevation | number | Dislivello totale in metri   |
+
+### Formato risposta API (`GET /api/strava`)
+
+```json
+{
+  "activities": [
+    {
+      "id": 123,
+      "name": "Morning Run",
+      "type": "Run",
+      "sportType": "Run",
+      "date": "2026-03-25T07:00:00Z",
+      "distance": 10000,
+      "movingTime": 3000,
+      "elevation": 150,
+      "averageSpeed": 3.33,
+      "kudos": 5,
+      "url": "https://www.strava.com/activities/123",
+      "formattedDistance": "10.0 km",
+      "formattedDuration": "50m",
+      "formattedPace": "5:00 /km",
+      "color": "#fc4c02",
+      "label": "Run",
+      "formattedDate": "Mar 25",
+      "hasDistance": true,
+      "formattedElevation": "↑150m"
+    }
+  ],
+  "stats": {
+    "weekly": {
+      "distance": "32.5 km",
+      "duration": "2h 45m",
+      "pace": "5:05 /km",
+      "elevation": "↑320m",
+      "count": 4
+    },
+    "monthly": { "..." : "..." }
+  },
+  "dailyBreakdown": [ "..." ],
+  "yearlyBreakdown": [ "..." ],
+  "typeDistribution": [ "..." ],
+  "weeklyRunStats": [ "..." ]
+}
+```
+
+## API Endpoints
+
+### `GET /api/strava`
+
+- **File**: `src/pages/api/strava.ts`
+- **Prerender**: `false` (serverless function)
+- **Autenticazione**: Nessuna (endpoint pubblico)
+- **Cache**: `Cache-Control: public, max-age=900` (15 minuti)
+- **Risposta successo**: `200` con body JSON (vedi formato sopra)
+- **Risposta errore**: `500` con `{ "error": "Internal error" }`
+
+L'endpoint esegue due chiamate parallele al service layer:
+1. `fetchRecentActivities(5)` — le ultime 5 attivita
+2. `fetchFullStats()` — statistiche complete dell'ultimo anno
+
+`fetchFullStats()` internamente pagina le attivita a blocchi di 200 (loop `while` fino a batch < 200), poi calcola:
+- **periodStats**: statistiche aggregate per gli ultimi 7 e 30 giorni
+- **dailyBreakdown**: breakdown giornaliero degli ultimi 30 giorni
+- **yearlyBreakdown**: breakdown giornaliero degli ultimi 365 giorni
+- **typeDistribution**: distribuzione per tipo di sport (ultimi 30 giorni)
+- **weeklyRunStats**: statistiche corsa per le ultime 8 settimane (solo `Run` e `TrailRun`)
+
+## Componenti UI
+
+### `ActivityCard.astro`
+
+Card singola per un'attivita. Mostra:
+- Dot colorato per tipo + etichetta tipo (es. "Run", "Trail")
+- Nome attivita (titolo)
+- Statistiche: distanza, durata, passo, dislivello
+- Data
+- Link esterno a Strava
+
+**Props**: `{ activity: NormalizedActivity }`
+
+### `ActivityList.astro`
+
+Lista compatta di attivita in formato riga. Ogni riga mostra: dot colorato, nome, statistiche (distanza, durata, passo, dislivello), data. Ogni riga e un link a Strava.
+
+**Props**: `{ activities: NormalizedActivity[] }`
+
+### `StravaSummary.astro`
+
+Riepilogo statistiche settimanali e mensili su due righe. Ogni riga mostra: badge periodo ("7d" / "30d" personalizzabili), distanza totale, numero attivita, passo medio, dislivello totale. I valori sono separati da un punto mediano (`·`).
+
+**Props**: `{ stats: PeriodStats; weekLabel?: string; monthLabel?: string }`
+
+### `RunWeeklyChart.astro`
+
+Grafico SVG inline che mostra l'andamento della corsa nelle ultime 8 settimane. Due linee sovrapposte:
+- **Linea continua arancione** (`#fc4c02`): distanza in km (con area riempita sotto)
+- **Linea tratteggiata gialla** (`#c8a000`): passo medio
+
+Caratteristiche:
+- Asse Y sinistro: distanza in km
+- Asse Y destro: passo (min:sec)
+- Asse X: etichette settimana (es. "3-9/2")
+- Indicatore numero corse sopra ogni punto (`3x`)
+- Evidenziazione della settimana migliore (dot piu grande + alone)
+- Tooltip SVG con dettagli
+- Stato vuoto: messaggio "Nessuna corsa recente"
+
+**Props**: `{ weeks: WeeklyRunStats[] }`
+
+Dimensioni SVG: viewBox `700x160`, padding 40px laterale, 24px top, 28px bottom.
+
+### `ActivityDonut.astro`
+
+Grafico a ciambella SVG che mostra la distribuzione delle attivita per tipo (ultimo mese). Al centro del donut: numero totale attivita. Legenda laterale con dot colorato, etichetta e percentuale.
+
+**Props**: `{ distribution: TypeDistribution[]; totalActivities: number }`
+
+Parametri SVG: viewBox `100x100`, raggio 36, stroke-width 8.
+
+## File coinvolti
+
+| File                                    | Ruolo                                     |
+|-----------------------------------------|-------------------------------------------|
+| `src/services/strava.ts`               | Service layer: auth, fetch, normalizzazione, aggregazione, formattazione |
+| `src/pages/api/strava.ts`              | Endpoint API serverless                   |
+| `src/components/ActivityCard.astro`     | Card singola attivita                     |
+| `src/components/ActivityCard.css`       | Stili card attivita                       |
+| `src/components/ActivityList.astro`     | Lista compatta attivita                   |
+| `src/components/ActivityList.css`       | Stili lista attivita                      |
+| `src/components/StravaSummary.astro`    | Riepilogo statistiche periodo             |
+| `src/components/StravaSummary.css`      | Stili riepilogo                           |
+| `src/components/RunWeeklyChart.astro`   | Grafico corsa settimanale                 |
+| `src/components/RunWeeklyChart.css`     | Stili grafico                             |
+| `src/components/ActivityDonut.astro`    | Grafico a ciambella distribuzione tipo    |
+| `src/components/ActivityDonut.css`      | Stili donut                               |
+
+## Dipendenze
+
+- **Astro 5** — Framework SSR/SSG, rendering componenti `.astro`
+- **Netlify Adapter** — Esecuzione endpoint serverless (`prerender: false`)
+- **Strava API v3** — Sorgente dati attivita (`/athlete/activities`)
+- **Strava OAuth2** — Refresh token grant per ottenere access token
+
+Nessuna dipendenza npm aggiuntiva: il service usa solo `fetch` nativo e logica pura per aggregazione, formattazione e calcolo statistiche.
+
+## Env vars
+
+| Variabile               | Obbligatoria | Descrizione                                        |
+|--------------------------|:------------:|----------------------------------------------------|
+| `STRAVA_CLIENT_ID`       | Si           | Client ID dell'app Strava                          |
+| `STRAVA_CLIENT_SECRET`   | Si           | Client Secret dell'app Strava                      |
+| `STRAVA_REFRESH_TOKEN`   | Si           | Refresh token con scope `activity:read_all`        |
+
+Tutte e tre sono necessarie per ottenere l'access token tramite il flusso OAuth2 refresh grant. L'access token non viene persistito: viene richiesto ad ogni invocazione dell'endpoint.
+
+## Limiti e trade-off
+
+1. **Token refresh ad ogni richiesta**: L'access token non viene cachato in memoria o su storage. Ogni chiamata a `/api/strava` genera un refresh token grant verso Strava. Questo semplifica l'architettura (nessun stato da gestire) ma raddoppia la latenza e consuma rate limit.
+
+2. **Rate limit Strava**: Le API Strava hanno limiti di 100 richieste ogni 15 minuti e 1000 al giorno. La cache HTTP di 15 minuti (`max-age=900`) mitiga il problema, ma in caso di deployment frequenti o cache miss multipli si rischia di raggiungere il limite.
+
+3. **Paginazione completa per le statistiche**: `fetchFullStats()` scarica tutte le attivita dell'ultimo anno con paginazione a blocchi di 200. Per utenti molto attivi questo puo significare piu richieste sequenziali all'API Strava, aumentando la latenza.
+
+4. **Nessuna persistenza dati**: I dati non vengono salvati su database. Ogni richiesta ricostruisce le statistiche da zero. Un crash dell'API Strava rende la sezione non disponibile.
+
+5. **Calcolo lato server**: Tutta l'aggregazione (daily breakdown, type distribution, weekly run stats) avviene nel serverless function. Per dataset grandi (365 giorni di attivita) il tempo di calcolo e trascurabile, ma la latenza di rete verso Strava domina.
+
+6. **Endpoint pubblico senza autenticazione**: `/api/strava` e accessibile a chiunque. La cache HTTP limita l'abuso, ma non c'e protezione esplicita contro scraping o attacchi volumetrici.
+
+7. **Formattazione date fissa in inglese**: Le date nelle attivita sono formattate in `en-us` (`"Mar 25"`), indipendentemente dalla lingua del sito. Il grafico settimanale ha invece etichette in italiano ("Corsa settimanale", "corse", "Nessuna corsa recente").
+
+8. **Solo corsa nel grafico settimanale**: `RunWeeklyChart` filtra solo attivita di tipo `Run` e `TrailRun`. Altre attivita con distanza (Ride, Swim, Walk) non compaiono nel grafico.
+
+9. **Mappa colori e etichette hardcoded**: I tipi di attivita supportati (Run, TrailRun, Walk, Hike, Ride, Swim, WeightTraining, Workout, Yoga, Crossfit) sono definiti in due lookup table statiche. Tipi non mappati ricevono un colore grigio di fallback (`#8a8a8e`) e usano il nome grezzo come etichetta.

--- a/src/pages/admin/meditation.astro
+++ b/src/pages/admin/meditation.astro
@@ -291,6 +291,7 @@ const quotesJson = JSON.stringify(allQuotes);
       .timer-btn.reset:hover { background: #444; color: #e8e6e1; }
       .timer-btn.voice { background: #333; color: #8a8a8e; font-size: 0.8rem; }
       .timer-btn.voice.active { background: rgba(155,89,182,0.2); color: #bb86fc; border: 1px solid rgba(155,89,182,0.3); }
+      .voice-tip { text-align: center; font-size: 0.75rem; color: #8a8a8e; margin-top: 0.5rem; font-style: italic; min-height: 1.2em; }
 
       /* Session card */
       .session-card {
@@ -510,6 +511,7 @@ const quotesJson = JSON.stringify(allQuotes);
         <button class="timer-btn reset" id="timer-reset">Reset</button>
         <button class="timer-btn voice active" id="voice-toggle">Voce ON</button>
       </div>
+      <div class="voice-tip" id="voice-tip"></div>
     </div>
 
     <div class="session-card" id="daily-session"></div>
@@ -634,36 +636,40 @@ const quotesJson = JSON.stringify(allQuotes);
         renderJourney(uniqueDates);
       }
 
-      // Adaptive journey plan
+      // Adaptive journey plan — shorter phases for faster variety
       var phases = [
-        { name: "Fondamenta", icon: "🌱", months: [0,1,2], minDur: 5, maxDur: 10,
+        { name: "Fondamenta", icon: "🌱", months: [0,1], minDur: 5, maxDur: 10,
           desc: "Costruisci l'abitudine. L'obiettivo non è meditare perfettamente, ma meditare ogni giorno. Anche 5 minuti contano.",
-          weights: { "Anapana": 70, "Body Scan": 20, "Camminata": 10 },
+          weights: { "Anapana": 75, "Body Scan": 15, "Camminata": 10 },
           spiritual: "Stai piantando il seme. La consapevolezza del respiro (Anapana) è la base di tutto il percorso Vipassana. Goenka insegna che senza questa padronanza, le pratiche successive non hanno fondamento." },
-        { name: "Consolidamento", icon: "🌿", months: [3,4,5], minDur: 10, maxDur: 15,
-          desc: "Allunghi le sessioni e inizi a esplorare il corpo. La mente diventa più stabile, i pensieri ti disturbano meno.",
-          weights: { "Anapana": 40, "Body Scan": 30, "Camminata": 15, "Pensieri": 15 },
+        { name: "Corpo", icon: "🌿", months: [2,3], minDur: 10, maxDur: 15,
+          desc: "Il respiro è stabile. Ora esplori il corpo: il Body Scan ti insegna ad ascoltare le sensazioni senza reagire.",
+          weights: { "Anapana": 30, "Body Scan": 40, "Camminata": 15, "Pensieri": 15 },
           spiritual: "Il seme germoglia. Inizi a notare pattern mentali ricorrenti. Il Body Scan ti insegna che il corpo parla una lingua che la mente razionale ignora. Ascoltalo." },
-        { name: "Espansione", icon: "🌳", months: [6,7,8], minDur: 15, maxDur: 20,
-          desc: "Introduci la Vipassana vera: osservazione profonda delle sensazioni. L'equanimità inizia a diventare naturale.",
-          weights: { "Anapana": 25, "Body Scan": 25, "Vipassana": 25, "Camminata": 15, "Pensieri": 10 },
+        { name: "Gentilezza", icon: "💛", months: [4,5], minDur: 10, maxDur: 20,
+          desc: "Introduci la Metta: amorevole gentilezza verso te stesso e gli altri. Scioglie le resistenze e prepara il terreno per Vipassana.",
+          weights: { "Anapana": 20, "Body Scan": 20, "Metta": 30, "Camminata": 15, "Pensieri": 15 },
+          spiritual: "Il cuore si apre. La gentilezza verso te stesso non è debolezza — è il coraggio di accettarti così come sei. Goenka dice: 'Senza metta, vipassana diventa arida'." },
+        { name: "Visione", icon: "🌳", months: [6,7,8], minDur: 15, maxDur: 20,
+          desc: "Vipassana vera: osservazione profonda delle sensazioni. L'equanimità inizia a diventare naturale.",
+          weights: { "Anapana": 15, "Body Scan": 15, "Vipassana": 30, "Metta": 15, "Camminata": 10, "Pensieri": 10, "Suono": 5 },
           spiritual: "L'albero cresce. Vipassana significa 'vedere le cose come realmente sono'. Scopri Anicca (impermanenza): ogni sensazione sorge e passa. Questa comprensione trasforma il rapporto con il dolore e il piacere." },
-        { name: "Approfondimento", icon: "🌲", months: [9,10,11], minDur: 15, maxDur: 25,
-          desc: "Sessioni più lunghe, pratiche più profonde. La Metta (amorevole gentilezza) bilancia l'intensità della Vipassana.",
-          weights: { "Anapana": 15, "Body Scan": 15, "Vipassana": 30, "Metta": 20, "Pensieri": 10, "Suono": 10 },
-          spiritual: "Radici profonde. L'equanimità non è indifferenza — è amore senza attaccamento. La Metta ti insegna a estendere gentilezza prima a te stesso, poi al mondo. Goenka dice: 'Senza metta, vipassana diventa arida'." },
+        { name: "Profondità", icon: "🌲", months: [9,10,11], minDur: 15, maxDur: 25,
+          desc: "Sessioni più lunghe, pratiche più profonde. Alterni tutte le tecniche con naturalezza.",
+          weights: { "Anapana": 10, "Body Scan": 15, "Vipassana": 25, "Metta": 20, "Pensieri": 10, "Suono": 10, "Camminata": 10 },
+          spiritual: "Radici profonde. L'equanimità non è indifferenza — è amore senza attaccamento. Il confine tra meditazione e vita quotidiana inizia ad assottigliarsi." },
         { name: "Maturità", icon: "🏔️", months: [12,13,14,15,16,17], minDur: 20, maxDur: 30,
-          desc: "La pratica si stabilizza. Ogni tipo di meditazione diventa accessibile. Puoi guidare la tua sessione in base a ciò che senti.",
-          weights: { "Anapana": 15, "Body Scan": 15, "Vipassana": 25, "Metta": 20, "Camminata": 10, "Pensieri": 10, "Suono": 5 },
-          spiritual: "La montagna. La pratica non è più qualcosa che 'fai' — diventa parte di chi sei. Il confine tra meditazione formale e vita quotidiana si assottiglia. Ogni momento diventa un'opportunità di consapevolezza." },
+          desc: "La pratica si stabilizza. Ogni tipo di meditazione è accessibile. Puoi guidare la sessione in base a ciò che senti.",
+          weights: { "Anapana": 10, "Body Scan": 10, "Vipassana": 25, "Metta": 20, "Camminata": 10, "Pensieri": 10, "Suono": 15 },
+          spiritual: "La montagna. La pratica non è più qualcosa che 'fai' — diventa parte di chi sei. Ogni momento è un'opportunità di consapevolezza. Considera un ritiro Vipassana di 10 giorni." },
         { name: "Integrazione", icon: "🌊", months: [18,19,20,21,22,23], minDur: 20, maxDur: 30,
           desc: "Pratichi con naturalezza. Puoi sostenere sessioni lunghe e doppi sit (mattina + sera). La consapevolezza permea la giornata.",
-          weights: { "Anapana": 10, "Body Scan": 15, "Vipassana": 25, "Metta": 20, "Camminata": 10, "Pensieri": 10, "Suono": 10 },
-          spiritual: "L'oceano. Come l'oceano è calmo nelle profondità anche quando la superficie è agitata, tu mantieni equanimità anche nelle tempeste della vita. Considera un ritiro Vipassana di 10 giorni per approfondire." },
+          weights: { "Anapana": 10, "Body Scan": 10, "Vipassana": 25, "Metta": 20, "Camminata": 10, "Pensieri": 10, "Suono": 15 },
+          spiritual: "L'oceano. Come l'oceano è calmo nelle profondità anche quando la superficie è agitata, tu mantieni equanimità anche nelle tempeste della vita." },
         { name: "Maestria", icon: "✨", months: [24], minDur: 30, maxDur: 45,
           desc: "La pratica è matura. Sei il tuo stesso maestro. Puoi esplorare sessioni lunghe, silenzio profondo, equanimità in ogni circostanza.",
-          weights: { "Anapana": 10, "Body Scan": 10, "Vipassana": 30, "Metta": 20, "Camminata": 10, "Pensieri": 10, "Suono": 10 },
-          spiritual: "La luce. Il percorso non ha fine — ogni sessione è sia inizio che completamento. Puoi insegnare agli altri attraverso il tuo esempio. La pratica quotidiana è il dono più grande che puoi fare a te stesso e al mondo." },
+          weights: { "Anapana": 10, "Body Scan": 10, "Vipassana": 25, "Metta": 20, "Camminata": 10, "Pensieri": 10, "Suono": 15 },
+          spiritual: "La luce. Il percorso non ha fine — ogni sessione è sia inizio che completamento. La pratica quotidiana è il dono più grande che puoi fare a te stesso e al mondo." },
       ];
 
       function getMonthsOfPractice(dates) {
@@ -747,6 +753,31 @@ const quotesJson = JSON.stringify(allQuotes);
             sess.steps.map(function(s, i) {
               return '<div class="step"><div class="step-num">' + (i + 1) + '</div><div class="step-content"><div class="step-title">' + s.t + '</div><div class="step-desc">' + s.d + '</div><span class="step-duration">' + s.dur + '</span></div></div>';
             }).join("");
+        }
+
+        // Voice: auto-off after training period, with tip
+        practiceDays = uniqueDates.length;
+        var voiceToggle = document.getElementById("voice-toggle");
+        var voiceTip = document.getElementById("voice-tip");
+        var userOverride = localStorage.getItem("meditation-voice-override");
+
+        if (userOverride !== null) {
+          voiceEnabled = userOverride === "on";
+        } else if (practiceDays >= VOICE_TRAINING_DAYS) {
+          voiceEnabled = false;
+        }
+
+        voiceToggle.textContent = voiceEnabled ? "Voce ON" : "Voce OFF";
+        voiceToggle.classList.toggle("active", voiceEnabled);
+
+        if (practiceDays >= VOICE_TRAINING_DAYS && voiceEnabled) {
+          voiceTip.textContent = "Hai " + practiceDays + " giorni di pratica — prova oggi senza voce, solo con i campanelli";
+        } else if (practiceDays >= VOICE_TRAINING_DAYS && !voiceEnabled) {
+          voiceTip.textContent = "Modalità silenziosa — i campanelli ti guidano tra gli step";
+        } else if (practiceDays >= Math.round(VOICE_TRAINING_DAYS * 0.7)) {
+          voiceTip.textContent = "Ancora " + (VOICE_TRAINING_DAYS - practiceDays) + " giorni, poi proverai a meditare in silenzio";
+        } else {
+          voiceTip.textContent = "";
         }
       }
 
@@ -984,6 +1015,8 @@ const quotesJson = JSON.stringify(allQuotes);
 
       // Voice
       var voiceEnabled = true;
+      var practiceDays = 0;
+      var VOICE_TRAINING_DAYS = 30;
       var cachedVoice = null;
       var voiceRetries = 0;
       function loadVoice() {
@@ -1045,6 +1078,15 @@ const quotesJson = JSON.stringify(allQuotes);
         this.textContent = voiceEnabled ? "Voce ON" : "Voce OFF";
         this.classList.toggle("active", voiceEnabled);
         if (!voiceEnabled) window.speechSynthesis.cancel();
+        localStorage.setItem("meditation-voice-override", voiceEnabled ? "on" : "off");
+        var voiceTip = document.getElementById("voice-tip");
+        if (practiceDays >= VOICE_TRAINING_DAYS && voiceEnabled) {
+          voiceTip.textContent = "Hai " + practiceDays + " giorni di pratica — prova oggi senza voce, solo con i campanelli";
+        } else if (practiceDays >= VOICE_TRAINING_DAYS && !voiceEnabled) {
+          voiceTip.textContent = "Modalità silenziosa — i campanelli ti guidano tra gli step";
+        } else {
+          voiceTip.textContent = "";
+        }
       });
 
       // Wake Lock

--- a/src/pages/admin/meditation.astro
+++ b/src/pages/admin/meditation.astro
@@ -1013,6 +1013,23 @@ const quotesJson = JSON.stringify(allQuotes);
         osc.start(ctx.currentTime); osc.stop(ctx.currentTime + 1);
       }
 
+      function playStepChimes(count) {
+        for (var i = 0; i < count; i++) {
+          (function(delay) {
+            setTimeout(function() {
+              var ctx = getAudioCtx();
+              var osc = ctx.createOscillator();
+              var gain = ctx.createGain();
+              osc.type = "sine"; osc.frequency.value = 780;
+              gain.gain.setValueAtTime(0.2, ctx.currentTime);
+              gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.6);
+              osc.connect(gain); gain.connect(ctx.destination);
+              osc.start(ctx.currentTime); osc.stop(ctx.currentTime + 0.6);
+            }, delay);
+          })(i * 500);
+        }
+      }
+
       // Voice
       var voiceEnabled = true;
       var practiceDays = 0;
@@ -1157,7 +1174,7 @@ const quotesJson = JSON.stringify(allQuotes);
             guidedStepIdx = step.idx;
             document.getElementById("breath-label").textContent = step.title;
             showGuide(step.idx + 1, totalSteps, step.title, step.desc, step.duration > 120 ? "Mantieni per " + Math.round(step.duration / 60) + " minuti" : "");
-            playChime();
+            playStepChimes(step.idx + 1);
             speak(step.title + ". " + step.desc);
             var halfWay = Math.round(step.duration / 2);
             if (halfWay > 30 && step.idx < schedule.length - 1) {
@@ -1176,7 +1193,7 @@ const quotesJson = JSON.stringify(allQuotes);
         var lastMin = setTimeout(function() {
           if (isRunning) {
             document.getElementById("guide-hint").textContent = "Un minuto alla fine...";
-            playChime();
+            playStepChimes(2);
             speak("Un minuto alla fine. Porta la consapevolezza a tutto il corpo.");
           }
         }, Math.max(0, timerTotal - 60) * 1000);


### PR DESCRIPTION
## Summary

### Fix audio meditazione
La voce guidata non si sentiva su mobile e Chrome desktop:
- **Bug Chrome 15 secondi**: keep-alive con `pause()/resume()` ogni 10s
- **Nessuna voce italiana**: fallback alla voce di default del sistema
- **Autoplay policy mobile**: AudioContext e speechSynthesis inizializzati al tap
- **Caricamento voci asincrono**: retry automatico (fino a 10 tentativi)
- **Ritorno dal background**: AudioContext ripristinato

### Percorso meditazione migliorato
- Fasi accorciate (2 mesi invece di 3) per più varietà prima
- Nuova fase "Gentilezza" (Metta) al mese 4-5, prima di Vipassana
- Voce guidata ON per i primi 30 giorni, poi OFF con suggerimento
- Scelta manuale voce salvata in localStorage

### Chime contati per orientarsi ad occhi chiusi
- 1 chime = step 1, 2 chime = step 2, ecc.
- Funziona sia con voce ON che OFF

### Specs documentazione
Aggiunte 9 spec in `docs/` per tutte le feature del progetto:
- `blog-spec.md`, `comments-spec.md`, `contact-spec.md`
- `lastfm-spec.md`, `letterboxd-spec.md`, `strava-spec.md`
- `meal-plan-spec.md`, `body-comp-spec.md`, `meditation-spec.md`

Aggiunta regola in CLAUDE.md: aggiornare sempre le spec alla fine di ogni feature.

## Test plan
- [ ] Voce funziona su Chrome desktop
- [ ] Voce funziona su Chrome Android / Safari iOS
- [ ] Chime contati: 1,2,3,4 chime per step 1,2,3,4
- [ ] Dopo 30 giorni di pratica, voce OFF di default
- [ ] Toggle voce persiste in localStorage
- [ ] Specs leggibili e accurate

https://claude.ai/code/session_01RCeuibt6sdNUUPbXnKvMEU