### PR TITLE
fix: menu mobile resta aperto dopo navigazione

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -54,4 +54,11 @@ const langSwitchHref = getLangSwitchHref(currentPath);
     menuToggle.classList.toggle("active");
     nav?.classList.toggle("active");
   });
+
+  nav?.querySelectorAll("a").forEach((link) => {
+    link.addEventListener("click", () => {
+      menuToggle?.classList.remove("active");
+      nav?.classList.remove("active");
+    });
+  });
 </script>


### PR DESCRIPTION
## Summary

- Menu hamburger mobile restava con la X dopo aver cliccato un link
- Aggiunto listener sui link del nav che rimuove la classe `active` al click

## Test plan

- [ ] Apri menu hamburger su mobile → clicca un link → menu si chiude
- [ ] Il toggle hamburger/X funziona ancora normalmente

https://claude.ai/code/session_01RCeuibt6sdNUUPbXnKvMEU