### PR TITLE
Sistema l'header su mobile (toggle tema non più orfano)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Built with **Astro 5**, deployed on **Netlify**, content in Markdown.
 ### Content
 - Blog posts and films live in `src/content/` as Markdown files, organized by locale (`it/`, `en/`)
 - External data fetched at build time: **Letterboxd** (movies), **Last.FM** (music), **Strava** (sport)
+- **Watched movies** also refresh client-side: pages render the build-time list as a fallback, then fetch `/api/letterboxd` on load so a freshly-logged film appears without a redeploy (see `docs/letterboxd-spec.md`)
 
 ### API Endpoints
 All endpoints use a `Result<T, E>` pattern — no exceptions, no silent failures. Every handler is a pipeline:

--- a/docs/analytics-spec.md
+++ b/docs/analytics-spec.md
@@ -78,7 +78,9 @@ Quando l'utente lascia la pagina o la nasconde, lo script invia un secondo beaco
 | `time_on_page` | Timer JS         | Secondi di permanenza (solo tempo con tab visibile) |
 | `scroll_depth` | `window.scrollY` | Percentuale massima raggiunta, arrotondata al 5%    |
 
-Questi vengono inviati con `navigator.sendBeacon()` su `visibilitychange` e collegati al pageview tramite un `page_id` generato client-side (UUID casuale, non persistente).
+Questi vengono inviati con `navigator.sendBeacon()` (fallback `fetch` con `keepalive`) e collegati al pageview tramite un `page_id` generato client-side (random, non persistente).
+
+Il beacon parte sia su `visibilitychange → hidden` (tab nascosta, switch app su mobile) sia su `pagehide` (chiusura tab e navigazioni hard, incluso bfcache). I due trigger sono coperti da un flag `sent` per evitare doppi invii; lato server l'`UPDATE ... WHERE time_on_page IS NULL` è comunque idempotente, quindi un eventuale doppio beacon è innocuo. Usare entrambi gli eventi è necessario perché `visibilitychange` da solo non scatta in modo affidabile su tutte le navigazioni/browser (es. Safari più datati), il che lasciava `time_on_page`/`scroll_depth` a `NULL`.
 
 ---
 
@@ -272,7 +274,7 @@ Script JS leggero (~2KB minificato) da caricare inline su ogni pagina.
 ### Comportamento
 
 1. **Pageview**: al caricamento della pagina, raccoglie i dati e invia `POST /api/collect` con `type: "pageview"`
-2. **Beacon**: su `visibilitychange` (tab nascosta/chiusa), invia `POST /api/collect` con `type: "beacon"` via `sendBeacon()`
+2. **Beacon**: su `visibilitychange → hidden` **e** su `pagehide`, invia `type: "beacon"` via `sendBeacon()` (con flag `sent` anti-doppio-invio)
 3. **SPA support**: override di `history.pushState` per tracciare navigazioni client-side (utile se in futuro il blog usa View Transitions)
 4. **Do Not Track**: se `navigator.doNotTrack === "1"`, non inviare nulla
 5. **Bot detection**: skip se `navigator.webdriver === true`
@@ -403,3 +405,15 @@ Aggiornare entrambe le versioni con testo tipo:
 - **Rate limiting in-memory**: si resetta ad ogni cold start della function. Per un blog personale e sufficiente.
 - **Niente real-time**: la dashboard mostra dati con un piccolo delay (query al DB). Nessun WebSocket.
 - **Chart.js aggiunge ~60KB**: se il peso e un problema, possiamo generare SVG server-side o usare un'alternativa leggera.
+
+### Caveat di accuratezza (come leggere i numeri)
+
+Questi non sono bug: sono conseguenze del modello di misurazione. Vanno tenuti presenti interpretando la dashboard.
+
+- **`time_on_page` / `scroll_depth` dipendono dal beacon.** Se il beacon non arriva (utente offline, browser che non emette né `visibilitychange` né `pagehide`), i due campi restano `NULL`. Gli `AVG` in SQLite ignorano i `NULL`, quindi **tempo medio e scroll medio riflettono solo le visite "ingaggiate"** e tendono a essere leggermente ottimistici. Il trigger su `pagehide` (vedi sopra) riduce molto i NULL ma non li azzera.
+- **`bounce_rate` tende a essere sovrastimato.** È calcolato come quota di unique visitor con `time_on_page < 5` **o `NULL`**: ogni visita senza beacon valido viene contata come rimbalzo.
+- **`visitors` su range multi-giorno = somma degli unici giornalieri.** `is_unique` è calcolato per giorno (l'hash visitatore include la data), e le stats fanno `SUM(is_unique)` sul periodo. Un visitatore che torna in 3 giorni diversi conta 3. Non è il numero di persone uniche sul periodo, ma di visite-uniche-per-giorno (stesso modello per-giorno di Plausible, ma senza dedup sull'intero range).
+- **Confine giornaliero in UTC.** `created_at` usa `datetime('now')` (UTC), quindi unicità e raggruppamenti per giorno seguono UTC, non Europe/Rome: le visite di tarda sera possono cadere nel giorno successivo. Irrilevante sui trend.
+- **`country` da timezone è grezzo e incompleto.** Mapping 1 timezone → 1 paese, con molti paesi non mappati → `country = NULL` (esclusi dal breakdown). Indicativo, non esatto.
+- **"Live" conta pageview attive, non utenti distinti.** `stats/live` fa `COUNT(DISTINCT page_id)` negli ultimi 5 minuti, e `page_id` è per-pageview: chi apre 3 pagine conta 3.
+- **`time_on_page` = tempo fino al primo `hidden`/`pagehide`.** Dopo il primo beacon il flag `sent` blocca invii successivi, quindi il tempo di chi torna sulla tab e poi la chiude non viene sommato.

--- a/docs/letterboxd-spec.md
+++ b/docs/letterboxd-spec.md
@@ -2,74 +2,83 @@
 
 ## Obiettivo
 
-Mostrare nella homepage i film visti di recente dall'utente Letterboxd `valenar`, arricchiti con poster e valutazione media da TMDB. I dati vengono recuperati a runtime tramite un endpoint serverless e renderizzati come card orizzontali scrollabili.
+Mostrare i film visti di recente dall'utente Letterboxd `valenar`, arricchiti con poster, regista, budget/box office, durata e valutazione da TMDB. I dati appaiono in tre superfici:
+
+- **Homepage** (`/`, `/en/`) — blocco "Visti di recente" / "Recently watched", ultimi 5 film.
+- **Pagina completa** (`/visti`, `/en/watched`) — lista completa raggruppata per anno, con statistiche (totale film, ultimi 7 giorni, ore guardate, voto medio).
+
+### Freschezza senza redeploy
+
+Il sito è statico (Astro SSG su Netlify). Per evitare che un film appena loggato su Letterboxd resti invisibile fino al prossimo deploy, le sezioni usano **progressive enhancement**:
+
+1. **Build time**: le pagine renderizzano la lista corrente come contenuto statico → ottimo per SEO, primo paint immediato, e fallback se JS è disabilitato o l'API è giù.
+2. **Client side**: al caricamento, uno script fa `fetch('/api/letterboxd')` e, se ottiene dati, **riscrive** la lista (e le statistiche, nella pagina completa) con i film freschi.
+
+Risultato: un film appena visto compare entro la finestra di cache dell'endpoint (~5 min), senza rebuild.
 
 ## Architettura
 
 ```
-Browser (client)
-     |
-     | GET /api/letterboxd
-     v
-+-----------------------------+
-| API Endpoint (Netlify fn)   |
-|  letterboxd.ts              |
-+-----------------------------+
-     |                    |
-     | 1. fetch RSS       | 2. per ogni film con tmdb:movieId
-     v                    v
-+-----------------+   +-------------------+
-| Letterboxd RSS  |   | TMDB API v3       |
-| /valenar/rss/   |   | /movie/{id}       |
-+-----------------+   +-------------------+
-     |                    |
-     | XML (RSS 2.0)      | JSON (dettagli film)
-     v                    v
-+-----------------------------+
-| Parsing + merge dati       |
-| title, posterPath,          |
-| voteAverage, link,          |
-| watchedDate                 |
-+-----------------------------+
-     |
-     | JSON array
-     v
-+-----------------------------+
-| Reel.astro (componente UI) |
-| card con poster, voto, data |
-+-----------------------------+
+Build time (statico)                 Client (runtime, ogni visita)
++-----------------------+            +------------------------------+
+| index/visti .astro    |            | <script> watched-movies.ts   |
+| fetch RSS+TMDB         |            |  fetchWatched()              |
+| render lista (fallback)|           |   -> GET /api/letterboxd     |
++-----------------------+            |  renderCompact / renderFull  |
+                                     +------------------------------+
+                                                  |
+                                                  v
+                                     +------------------------------+
+                                     | API Endpoint (Netlify fn)    |
+                                     |  src/pages/api/letterboxd.ts |
+                                     |  prerender = false           |
+                                     +------------------------------+
+                                         |                    |
+                                         | getLetterboxdRss() | getMovieById() (per film)
+                                         v                    v
+                                  +----------------+   +-------------------+
+                                  | Letterboxd RSS |   | TMDB API v3       |
+                                  | /valenar/rss/  |   | /movie/{id}       |
+                                  +----------------+   | append: credits   |
+                                                       +-------------------+
 ```
+
+L'endpoint **riusa i service** `letterboxd.ts` e `tmdb.ts` (niente più logica duplicata inline).
 
 ## Dati
 
-### Dati estratti dal feed RSS Letterboxd
+### Estratti dal feed RSS Letterboxd
 
-| Campo                       | Origine            | Descrizione                        |
-| --------------------------- | ------------------ | ---------------------------------- |
-| `letterboxd:filmTitle`      | RSS item           | Titolo del film su Letterboxd      |
-| `tmdb:movieId`              | RSS item           | ID TMDB (usato come chiave join)   |
-| `letterboxd:watchedDate`    | RSS item           | Data di visione (YYYY-MM-DD)       |
-| `link`                      | RSS item           | URL della review su Letterboxd     |
+| Campo                    | Descrizione                        |
+| ------------------------ | ---------------------------------- |
+| `letterboxd:filmTitle`   | Titolo del film su Letterboxd      |
+| `tmdb:movieId`           | ID TMDB (chiave join, obbligatorio)|
+| `letterboxd:watchedDate` | Data di visione (YYYY-MM-DD)       |
+| `letterboxd:memberRating`| Voto personale (es. "4.0")         |
+| `link`                   | URL della review su Letterboxd     |
 
-### Dati arricchiti da TMDB
+Gli item senza `tmdb:movieId` vengono scartati.
 
-| Campo          | Origine       | Descrizione                              |
-| -------------- | ------------- | ---------------------------------------- |
-| `poster_path`  | TMDB API      | Path relativo del poster (w500)          |
-| `vote_average` | TMDB API      | Voto medio della community TMDB          |
-| `vote_count`   | TMDB API      | Numero totale di voti                    |
-| `title`        | TMDB API      | Titolo (fallback se manca dal RSS)       |
+### Arricchiti da TMDB (`/movie/{id}?append_to_response=credits`)
+
+`poster_path`, `budget`, `revenue`, `overview`, `release_date`, `vote_average`, `runtime`, e i registi estratti da `credits.crew` (`job === "Director"`, deduplicati) via `extractDirectors()`.
 
 ### Oggetto restituito al client
 
 ```ts
 {
-  title: string;         // titolo film (RSS, fallback TMDB)
-  posterPath: string;    // path poster TMDB (es. "/abc123.jpg")
-  voteAverage: number;   // media voti TMDB
-  voteCount: number;     // conteggio voti TMDB
-  link: string;          // URL review Letterboxd
-  watchedDate: string;   // data visione (YYYY-MM-DD)
+  title: string;
+  posterPath: string | null;
+  budget: number | null;
+  revenue: number | null;
+  directors: string[];
+  overview: string | null;
+  releaseDate: string | null;   // YYYY-MM-DD
+  voteAverage: number | null;
+  runtime: number | null;       // minuti
+  rating: string | null;        // voto personale Letterboxd
+  watchedDate: string | null;   // YYYY-MM-DD
+  link: string;
 }
 ```
 
@@ -77,78 +86,57 @@ Browser (client)
 
 ### `GET /api/letterboxd`
 
-- **Prerender**: `false` (serverless, eseguito a runtime)
+- **Prerender**: `false` (serverless, runtime)
 - **Autenticazione**: nessuna (endpoint pubblico)
-- **Cache**: `Cache-Control: public, max-age=900` (15 minuti)
+- **Cache**: `Cache-Control: public, max-age=300, s-maxage=300, stale-while-revalidate=600` — 5 min browser + CDN, così sotto traffico le chiamate a TMDB restano limitate.
 - **Flusso**:
-  1. Fetch RSS da `https://letterboxd.com/valenar/rss/`
-  2. Parsing XML con `xml2js.parseString`
-  3. Filtra solo gli item con `tmdb:movieId` presente
-  4. Per ogni item, chiama TMDB API v3 `/movie/{id}` in parallelo (`Promise.all`)
-  5. Merge dati RSS + TMDB, scarta eventuali film falliti (`null`)
-  6. Restituisce array JSON
-- **Risposte di errore**:
-  - `502` se il fetch RSS fallisce
-  - `500` per errori interni generici
+  1. `getLetterboxdRss()` → fetch RSS `https://letterboxd.com/valenar/rss/`
+  2. `parseXmlContent()` (xml2js)
+  3. Filtra gli item con `tmdb:movieId`
+  4. Per ogni item, `getMovieById()` in parallelo (`Promise.all`); i film falliti diventano `null` e vengono scartati
+  5. Mappa allo shape camelCase sopra, preserva l'ordine del feed (più recente prima)
+- **Errori**: `500` per errori interni; i singoli film che falliscono vengono semplicemente omessi.
 
-## Componenti UI
+## Rendering client (`src/scripts/watched-movies.ts`)
 
-### `Reel.astro`
+Modulo bundlato lato client (import-abile dagli `<script>` Astro). Costruisce il DOM con `document.createElement` (niente `innerHTML` su dati esterni → no XSS). Riusa gli helper puri `formatMoneyCompact` e `letterboxdDirectorUrl`.
 
-Componente riutilizzabile per card di film e brani musicali in uno scroll orizzontale.
+| Export | Ruolo |
+| --- | --- |
+| `fetchWatched()` | `GET /api/letterboxd`, ritorna `WatchedMovie[]` (o `[]`) |
+| `renderCompact(block, movies, opts)` | Riscrive la lista a 5 film della homepage |
+| `renderFull(main, movies, opts)` | Raggruppa per anno, riscrive la lista completa e aggiorna le statistiche |
 
-**Props** (tipo `movie`):
-
-| Prop           | Tipo     | Descrizione                        |
-| -------------- | -------- | ---------------------------------- |
-| `url`          | string   | URL completa immagine poster       |
-| `href`         | string   | Link esterno (Letterboxd)          |
-| `title`        | string   | Titolo del film                    |
-| `watchedDate`  | string   | Data visione                       |
-| `vote_average` | number?  | Voto medio TMDB                    |
-| `vote_count`   | number?  | Conteggio voti TMDB                |
-| `type`         | `"movie" \| "song"` | Determina layout della card |
-
-**Comportamento**:
-- Poster con dimensione fissa (160x240 mobile, 185x278 desktop)
-- Badge voto sovrapposto in alto a destra (font mono, sfondo semi-trasparente con blur)
-- Placeholder SVG se il poster manca o fallisce il caricamento (`onerror` inline)
-- Data formattata in formato breve inglese (es. "Mar 15")
-- Titolo troncato a 2 righe con `-webkit-line-clamp`
-- Hover: zoom 1.05 + brightness 1.1 sul poster
+`opts` porta `locale` (`it-IT` / `en-GB`), `byLabel` ("di" / "by") e, per la full, `myRatingLabel`. Le pagine espongono hook `data-*` (`data-watched-home`, `data-watched-list`, `data-watched-main`, `data-stat="total|week|hours|rating"`).
 
 ## File coinvolti
 
 | File | Ruolo |
 | --- | --- |
-| `src/pages/api/letterboxd.ts` | Endpoint serverless — fetch RSS, join TMDB, ritorna JSON |
-| `src/services/letterboxd.ts` | Service layer — `getLetterboxdRss()` e `parseXmlContent()` (utility riusabili) |
-| `src/services/tmdb.ts` | Service layer — `getMovieById()`, costanti API TMDB |
-| `src/components/Reel.astro` | Componente card (condiviso con Last.FM) |
-| `src/components/Reel.css` | Stili co-locati del componente Reel |
-
-**Nota**: l'endpoint `api/letterboxd.ts` attualmente duplica parte della logica presente nei service (`letterboxd.ts`, `tmdb.ts`) invece di importarli direttamente. I service sono disponibili per un eventuale refactoring.
+| `src/pages/api/letterboxd.ts` | Endpoint serverless — fetch RSS, join TMDB, ritorna JSON arricchito |
+| `src/scripts/watched-movies.ts` | Fetch + rendering client (homepage compatta + pagina completa) |
+| `src/services/letterboxd.ts` | `getLetterboxdRss()`, `parseXmlContent()` |
+| `src/services/tmdb.ts` | `getMovieById()` (append credits), `extractDirectors()` |
+| `src/pages/index.astro`, `src/pages/en/index.astro` | Homepage — render build-time + `<script>` `renderCompact` |
+| `src/pages/visti.astro`, `src/pages/en/watched.astro` | Pagina completa — render build-time + `<script>` `renderFull` |
 
 ## Dipendenze
 
-| Pacchetto | Versione | Utilizzo |
-| --- | --- | --- |
-| `xml2js` | — | Parsing XML del feed RSS Letterboxd |
-| `astro` | 5.x | Framework, routing, endpoint serverless |
+| Pacchetto | Utilizzo |
+| --- | --- |
+| `xml2js` | Parsing XML del feed RSS Letterboxd |
+| `astro` 5.x | Framework, routing, endpoint serverless, bundling script client |
 
 ## Env vars
 
 | Variabile | Obbligatoria | Descrizione |
 | --- | --- | --- |
-| `TMDB_API_KEY` | Si | API key per The Movie Database (v3) |
+| `TMDB_API_KEY` | Sì | API key per The Movie Database (v3) |
 
 ## Limiti e trade-off
 
-- **Nessuna cache persistente**: i dati vengono recuperati ad ogni richiesta (mitigato dal `max-age=900` HTTP). Non c'e' un layer di cache server-side (Redis, KV store, ecc.).
-- **Rate limiting TMDB**: ogni chiamata all'endpoint genera N richieste parallele a TMDB (una per film nel feed RSS). Con feed lunghi si rischia di superare i rate limit TMDB.
-- **Chiamate N+1**: il pattern e' 1 fetch RSS + N fetch TMDB. Non c'e' batching (TMDB non offre un endpoint bulk per ID multipli).
-- **Duplicazione logica**: l'endpoint `api/letterboxd.ts` reimplementa parsing XML e fetch TMDB inline, invece di riusare `src/services/letterboxd.ts` e `src/services/tmdb.ts`.
-- **Nessuna validazione schema**: la risposta TMDB e il feed RSS non vengono validati con Zod o simili; si usa `any` per il parsing.
-- **Utente hardcoded**: il profilo Letterboxd `valenar` e' hardcoded sia nell'endpoint che nel service.
-- **Nessun limite item**: tutti gli item del feed RSS con `tmdb:movieId` vengono processati. Il feed Letterboxd puo' contenere decine di entry.
-- **Immagini TMDB w500**: il poster viene servito in formato `w500` (via costante `IMAGES_URL` nel service), adeguato per le dimensioni della card ma potenzialmente sovradimensionato per mobile.
+- **Doppio rendering**: la stessa lista è renderizzata sia in `.astro` (build) sia in TS (client). È duplicazione voluta — il costo è il prezzo del progressive enhancement (SEO + fallback + freschezza).
+- **Chiamate N+1**: 1 fetch RSS + N fetch TMDB. Nessun batching (TMDB non offre endpoint bulk). Mitigato dalla cache CDN a 5 min.
+- **Nessuna validazione schema**: RSS e risposta TMDB non sono validati con Zod; il parsing dell'XML usa `any` (coerente con gli altri service).
+- **Utente hardcoded**: il profilo `valenar` è hardcoded nel service.
+- **Nessun limite item**: tutti gli item con `tmdb:movieId` vengono processati.

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -117,16 +117,18 @@ const fullImageUrl = new URL(socialImage, Astro.url);
     screen_width:screen.width,screen_height:screen.height,viewport_width:innerWidth,viewport_height:innerHeight,
     language:navigator.language,timezone:Intl.DateTimeFormat().resolvedOptions().timeZone};
   send(data).catch(function(){try{localStorage.setItem("_ae",JSON.stringify(data));}catch(e){}});
-  var start=Date.now(),maxScroll=0,hidden=false;
+  var start=Date.now(),maxScroll=0,sent=false;
   function onScroll(){var h=document.documentElement.scrollHeight-innerHeight;if(h>0){var pct=Math.round(scrollY/h*100/5)*5;if(pct>maxScroll)maxScroll=pct;}}
   window.addEventListener("scroll",onScroll,{passive:true});
-  document.addEventListener("visibilitychange",function(){
-    if(document.visibilityState==="hidden"&&!hidden){
-      hidden=true;
-      var t=Math.round((Date.now()-start)/1000);
-      navigator.sendBeacon(EP,JSON.stringify({type:"beacon",page_id:id,time_on_page:t,scroll_depth:maxScroll}));
-    }
-  });
+  function flush(){
+    if(sent)return;sent=true;
+    var t=Math.round((Date.now()-start)/1000);
+    var beacon={type:"beacon",page_id:id,time_on_page:t,scroll_depth:maxScroll};
+    if(navigator.sendBeacon){navigator.sendBeacon(EP,JSON.stringify(beacon));}
+    else{send(beacon).catch(function(){});}
+  }
+  document.addEventListener("visibilitychange",function(){if(document.visibilityState==="hidden")flush();});
+  window.addEventListener("pagehide",flush);
 })();
 </script>
 

--- a/src/components/FoglioHeader.astro
+++ b/src/components/FoglioHeader.astro
@@ -32,12 +32,15 @@ function isActive(id: string): boolean {
 
 <nav class="foglio-nav">
   <a href={isEn ? "/en/" : "/"} class="foglio-nav-brand">Valerio Narcisi</a>
-  <div class="foglio-nav-links">
-    {links.map((link) => (
-      <a href={link.href} class={isActive(link.id) ? "is-active" : ""}>
-        {link.label}
-      </a>
-    ))}
+  <div class="foglio-nav-right">
+    <div class="foglio-nav-links">
+      {links.map((link) => (
+        <a href={link.href} class={isActive(link.id) ? "is-active" : ""}>
+          {link.label}
+        </a>
+      ))}
+    </div>
+    <div class="foglio-nav-meta">
     <a href={langSwitchHref}>{langSwitchLabel}</a>
     <button id="ft-toggle" class="ft-toggle" aria-label="Toggle theme">
       <svg class="ft-sun" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
@@ -55,6 +58,7 @@ function isActive(id: string): boolean {
         <path d="M13.5 10A6 6 0 0 1 6 2.5a6 6 0 1 0 7.5 7.5z"/>
       </svg>
     </button>
+    </div>
   </div>
 </nav>
 

--- a/src/pages/api/letterboxd.ts
+++ b/src/pages/api/letterboxd.ts
@@ -1,50 +1,34 @@
 import type { APIRoute } from "astro";
-import { parseString } from "xml2js";
-import { env } from "~/lib/env";
+import { getLetterboxdRss, parseXmlContent } from "~/services/letterboxd";
+import { getMovieById, extractDirectors } from "~/services/tmdb";
 
 export const prerender = false;
 
-const TMDB_API_KEY = env("TMDB_API_KEY");
-
-const parseXml = (xml: string): Promise<any> =>
-  new Promise((resolve, reject) => {
-    parseString(xml, (err, result) => {
-      if (err) reject(err);
-      else resolve(result);
-    });
-  });
-
 export const GET: APIRoute = async () => {
   try {
-    const rssResponse = await fetch("https://letterboxd.com/valenar/rss/");
-    if (!rssResponse.ok) {
-      return new Response(JSON.stringify({ error: "Failed to fetch RSS" }), {
-        status: 502,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-
-    const xml = await rssResponse.text();
-    const parsed = await parseXml(xml);
-    const items = parsed.rss.channel[0].item.filter(
-      (item: any) => item?.["tmdb:movieId"]?.[0],
+    const rss = await getLetterboxdRss();
+    const parsed = (await parseXmlContent(await rss.text())) as any;
+    const items = (parsed?.rss?.channel?.[0]?.item ?? []).filter(
+      (it: any) => it?.["tmdb:movieId"]?.[0],
     );
 
     const movies = await Promise.all(
-      items.map(async (item: any) => {
+      items.map(async (it: any) => {
         try {
-          const tmdbResponse = await fetch(
-            `https://api.themoviedb.org/3/movie/${item["tmdb:movieId"][0]}?api_key=${TMDB_API_KEY}`,
-          );
-          if (!tmdbResponse.ok) return null;
-          const movie = await tmdbResponse.json();
+          const movie: any = await getMovieById(it["tmdb:movieId"][0]);
           return {
-            title: item["letterboxd:filmTitle"]?.[0] ?? movie.title,
-            posterPath: movie.poster_path,
-            voteAverage: movie.vote_average,
-            voteCount: movie.vote_count,
-            link: item.link?.[0] ?? "",
-            watchedDate: item["letterboxd:watchedDate"]?.[0] ?? "",
+            title: it["letterboxd:filmTitle"]?.[0] ?? movie.title ?? "",
+            posterPath: movie.poster_path ?? null,
+            budget: typeof movie.budget === "number" ? movie.budget : null,
+            revenue: typeof movie.revenue === "number" ? movie.revenue : null,
+            directors: extractDirectors(movie),
+            overview: movie.overview ?? null,
+            releaseDate: movie.release_date ?? null,
+            voteAverage: typeof movie.vote_average === "number" ? movie.vote_average : null,
+            runtime: typeof movie.runtime === "number" ? movie.runtime : null,
+            rating: it["letterboxd:memberRating"]?.[0] ?? null,
+            watchedDate: it["letterboxd:watchedDate"]?.[0] ?? null,
+            link: it.link?.[0] ?? "",
           };
         } catch {
           return null;
@@ -55,7 +39,7 @@ export const GET: APIRoute = async () => {
     return new Response(JSON.stringify(movies.filter(Boolean)), {
       headers: {
         "Content-Type": "application/json",
-        "Cache-Control": "public, max-age=300, stale-while-revalidate=600",
+        "Cache-Control": "public, max-age=300, s-maxage=300, stale-while-revalidate=600",
       },
     });
   } catch {

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -230,10 +230,10 @@ function formatDate(dateStr: string | Date): string {
     <!-- 5. Library -->
     <section class="fh-library">
       <div class="fh-library-inner">
-        <div class="fh-lib-block">
+        <div class="fh-lib-block" data-watched-home>
           <h3>Recently watched.</h3>
           {lastWatched.length > 0 ? (
-            <ul class="fh-lib-list fh-lib-list--films">
+            <ul class="fh-lib-list fh-lib-list--films" data-watched-list>
               {(lastWatched as any[]).slice(0, 5).map((movie: any) => (
                 <li>
                   <div
@@ -314,5 +314,17 @@ function formatDate(dateStr: string | Date): string {
     </section>
 
     <FoglioFooter lang="en" />
+
+    <script>
+      import { fetchWatched, renderCompact } from "~/scripts/watched-movies";
+      const block = document.querySelector<HTMLElement>("[data-watched-home]");
+      if (block) {
+        fetchWatched()
+          .then((movies) => {
+            if (movies.length > 0) renderCompact(block, movies, { locale: "en-GB", byLabel: "by" });
+          })
+          .catch(() => {});
+      }
+    </script>
   </body>
 </html>

--- a/src/pages/en/watched.astro
+++ b/src/pages/en/watched.astro
@@ -123,24 +123,24 @@ if (myRatings.length > 0) {
       <dl class="vw-stats">
         <div class="vw-stat">
           <dt>Films</dt>
-          <dd>{totalCount}</dd>
+          <dd data-stat="total">{totalCount}</dd>
         </div>
         <div class="vw-stat">
           <dt>Last 7 days</dt>
-          <dd>{lastWeekCount}</dd>
+          <dd data-stat="week">{lastWeekCount}</dd>
         </div>
         <div class="vw-stat">
           <dt>Hours watched</dt>
-          <dd>{totalHours} h</dd>
+          <dd data-stat="hours">{totalHours} h</dd>
         </div>
         <div class="vw-stat">
           <dt>Average rating</dt>
-          <dd>{avgLabel}</dd>
+          <dd data-stat="rating">{avgLabel}</dd>
         </div>
       </dl>
     </header>
 
-    <main class="vw-main">
+    <main class="vw-main" data-watched-main>
       {totalCount === 0 ? (
         <p class="vw-empty">No data available right now.</p>
       ) : (
@@ -205,5 +205,22 @@ if (myRatings.length > 0) {
     </main>
 
     <FoglioFooter lang="en" />
+
+    <script>
+      import { fetchWatched, renderFull } from "~/scripts/watched-movies";
+      const main = document.querySelector<HTMLElement>("[data-watched-main]");
+      if (main) {
+        fetchWatched()
+          .then((movies) => {
+            if (movies.length > 0)
+              renderFull(main, movies, {
+                locale: "en-GB",
+                byLabel: "by",
+                myRatingLabel: (r) => `my rating: ${r}/5`,
+              });
+          })
+          .catch(() => {});
+      }
+    </script>
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -229,10 +229,10 @@ function formatDate(dateStr: string | Date): string {
     <!-- 5. Library -->
     <section class="fh-library">
       <div class="fh-library-inner">
-        <div class="fh-lib-block">
+        <div class="fh-lib-block" data-watched-home>
           <h3>Visti di recente.</h3>
           {lastWatched.length > 0 ? (
-            <ul class="fh-lib-list fh-lib-list--films">
+            <ul class="fh-lib-list fh-lib-list--films" data-watched-list>
               {(lastWatched as any[]).slice(0, 5).map((movie: any) => (
                 <li>
                   <div
@@ -313,5 +313,17 @@ function formatDate(dateStr: string | Date): string {
     </section>
 
     <FoglioFooter lang="it" />
+
+    <script>
+      import { fetchWatched, renderCompact } from "~/scripts/watched-movies";
+      const block = document.querySelector<HTMLElement>("[data-watched-home]");
+      if (block) {
+        fetchWatched()
+          .then((movies) => {
+            if (movies.length > 0) renderCompact(block, movies, { locale: "it-IT", byLabel: "di" });
+          })
+          .catch(() => {});
+      }
+    </script>
   </body>
 </html>

--- a/src/pages/visti.astro
+++ b/src/pages/visti.astro
@@ -123,24 +123,24 @@ if (myRatings.length > 0) {
       <dl class="vw-stats">
         <div class="vw-stat">
           <dt>Film</dt>
-          <dd>{totalCount}</dd>
+          <dd data-stat="total">{totalCount}</dd>
         </div>
         <div class="vw-stat">
           <dt>Ultimi 7 giorni</dt>
-          <dd>{lastWeekCount}</dd>
+          <dd data-stat="week">{lastWeekCount}</dd>
         </div>
         <div class="vw-stat">
           <dt>Ore guardate</dt>
-          <dd>{totalHours} h</dd>
+          <dd data-stat="hours">{totalHours} h</dd>
         </div>
         <div class="vw-stat">
           <dt>Voto medio</dt>
-          <dd>{avgLabel}</dd>
+          <dd data-stat="rating">{avgLabel}</dd>
         </div>
       </dl>
     </header>
 
-    <main class="vw-main">
+    <main class="vw-main" data-watched-main>
       {totalCount === 0 ? (
         <p class="vw-empty">Nessun dato disponibile al momento.</p>
       ) : (
@@ -206,5 +206,21 @@ if (myRatings.length > 0) {
 
     <FoglioFooter lang="it" />
 
+    <script>
+      import { fetchWatched, renderFull } from "~/scripts/watched-movies";
+      const main = document.querySelector<HTMLElement>("[data-watched-main]");
+      if (main) {
+        fetchWatched()
+          .then((movies) => {
+            if (movies.length > 0)
+              renderFull(main, movies, {
+                locale: "it-IT",
+                byLabel: "di",
+                myRatingLabel: (r) => `il mio: ${r}/5`,
+              });
+          })
+          .catch(() => {});
+      }
+    </script>
   </body>
 </html>

--- a/src/scripts/watched-movies.ts
+++ b/src/scripts/watched-movies.ts
@@ -1,0 +1,238 @@
+import { formatMoneyCompact } from "~/lib/format-money";
+import { letterboxdDirectorUrl } from "~/lib/letterboxd-slug";
+
+export interface WatchedMovie {
+  title: string;
+  posterPath: string | null;
+  budget: number | null;
+  revenue: number | null;
+  directors: string[];
+  overview: string | null;
+  releaseDate: string | null;
+  voteAverage: number | null;
+  runtime: number | null;
+  rating: string | null;
+  watchedDate: string | null;
+  link: string;
+}
+
+export interface CompactOptions {
+  locale: string;
+  byLabel: string;
+}
+
+export interface FullOptions {
+  locale: string;
+  byLabel: string;
+  myRatingLabel: (rating: string) => string;
+}
+
+type Child = Node | string | null | undefined | false;
+
+function el(
+  tag: string,
+  attrs?: Record<string, string> | null,
+  ...children: Child[]
+): HTMLElement {
+  const node = document.createElement(tag);
+  if (attrs) {
+    for (const [k, v] of Object.entries(attrs)) node.setAttribute(k, v);
+  }
+  for (const child of children) {
+    if (child == null || child === false) continue;
+    node.append(typeof child === "string" ? document.createTextNode(child) : child);
+  }
+  return node;
+}
+
+function formatDate(raw: string | null, locale: string): string {
+  if (!raw) return "";
+  const d = new Date(raw);
+  if (isNaN(d.getTime())) return raw;
+  return d.toLocaleDateString(locale, { day: "numeric", month: "short", year: "numeric" });
+}
+
+export async function fetchWatched(): Promise<WatchedMovie[]> {
+  const res = await fetch("/api/letterboxd");
+  if (!res.ok) throw new Error(`Failed to fetch watched movies: ${res.status}`);
+  const data = await res.json();
+  return Array.isArray(data) ? (data as WatchedMovie[]) : [];
+}
+
+function compactItem(m: WatchedMovie, opts: CompactOptions): HTMLElement {
+  const cover = el("div", { class: "fh-lib-cover" });
+  if (m.posterPath) {
+    cover.style.backgroundImage = `url('https://image.tmdb.org/t/p/w92/${m.posterPath}')`;
+  }
+
+  const title = el("div", { class: "fh-lib-title" }, el("em", null, m.title));
+
+  const b = formatMoneyCompact(m.budget);
+  const r = formatMoneyCompact(m.revenue);
+  if (b || r) {
+    title.append(
+      el(
+        "span",
+        { class: "fh-lib-money", title: "Budget → Box office" },
+        `${b ?? "—"} `,
+        el("span", { class: "fh-lib-money-arrow" }, "→"),
+        ` ${r ?? "—"}`,
+      ),
+    );
+  }
+
+  if (m.directors.length > 0) {
+    title.append(
+      el("span", { class: "fh-lib-director" }, `${opts.byLabel} ${m.directors.join(", ")}`),
+    );
+  }
+
+  const detail = el("div", { class: "fh-lib-detail" }, formatDate(m.watchedDate, opts.locale));
+  return el("li", null, cover, title, detail);
+}
+
+export function renderCompact(
+  block: HTMLElement,
+  movies: WatchedMovie[],
+  opts: CompactOptions,
+): void {
+  const ul = el("ul", { class: "fh-lib-list fh-lib-list--films" });
+  ul.setAttribute("data-watched-list", "");
+  for (const m of movies.slice(0, 5)) ul.append(compactItem(m, opts));
+
+  const existing = block.querySelector("ul[data-watched-list], .fh-lib-fallback");
+  if (existing) {
+    existing.replaceWith(ul);
+    return;
+  }
+  const actions = block.querySelector(".fh-lib-actions");
+  if (actions) block.insertBefore(ul, actions);
+  else block.append(ul);
+}
+
+function fullRow(m: WatchedMovie, opts: FullOptions): HTMLElement {
+  const cover = el("div", { class: "vw-cover" });
+  if (m.posterPath) {
+    cover.style.backgroundImage = `url('https://image.tmdb.org/t/p/w185/${m.posterPath}')`;
+  }
+
+  const col = el("div", { class: "vw-main-col" }, el("h3", { class: "vw-title" }, m.title));
+
+  if (m.directors.length > 0) {
+    const span = el("span");
+    m.directors.forEach((d, i) => {
+      if (i > 0) span.append(", ");
+      span.append(
+        el(
+          "a",
+          {
+            class: "vw-director-link",
+            href: letterboxdDirectorUrl(d),
+            target: "_blank",
+            rel: "noopener noreferrer",
+          },
+          d,
+        ),
+      );
+    });
+    col.append(el("p", { class: "vw-director" }, `${opts.byLabel} `, span));
+  }
+
+  if (m.overview) col.append(el("p", { class: "vw-overview" }, m.overview));
+
+  const meta = el("div", { class: "vw-meta" });
+  if (m.releaseDate) meta.append(el("span", null, m.releaseDate.slice(0, 4)));
+  if (typeof m.runtime === "number" && m.runtime > 0) {
+    meta.append(el("span", null, `${m.runtime}′`));
+  }
+  if (typeof m.voteAverage === "number" && m.voteAverage > 0) {
+    meta.append(el("span", null, `★ ${m.voteAverage.toFixed(1)}`));
+  }
+  if (m.rating) {
+    meta.append(el("span", { class: "vw-my-rating" }, opts.myRatingLabel(m.rating)));
+  }
+  col.append(meta);
+
+  const side = el("div", { class: "vw-side" });
+  const b = formatMoneyCompact(m.budget);
+  const r = formatMoneyCompact(m.revenue);
+  if (b || r) {
+    side.append(
+      el(
+        "div",
+        { class: "vw-money" },
+        el("span", { class: "vw-money-budget" }, b ?? "—"),
+        el("span", { class: "vw-money-arrow" }, "→"),
+        el("span", { class: "vw-money-revenue" }, r ?? "—"),
+      ),
+    );
+  }
+  side.append(el("time", { class: "vw-date" }, formatDate(m.watchedDate, opts.locale)));
+
+  return el("li", { class: "vw-row" }, cover, col, side);
+}
+
+function setStat(key: string, value: string): void {
+  const node = document.querySelector(`[data-stat="${key}"]`);
+  if (node) node.textContent = value;
+}
+
+function updateStats(movies: WatchedMovie[]): void {
+  const weekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  const week = movies.filter((m) => {
+    const t = m.watchedDate ? new Date(m.watchedDate).getTime() : NaN;
+    return Number.isFinite(t) && t >= weekAgo;
+  }).length;
+
+  const minutes = movies.reduce(
+    (s, m) => s + (typeof m.runtime === "number" && m.runtime > 0 ? m.runtime : 0),
+    0,
+  );
+
+  const myRatings = movies
+    .map((m) => (m.rating ? Number(m.rating) : NaN))
+    .filter((n) => Number.isFinite(n) && n > 0);
+  const tmdbRatings = movies
+    .map((m) => (typeof m.voteAverage === "number" ? m.voteAverage : NaN))
+    .filter((n) => Number.isFinite(n) && n > 0);
+
+  let avg = "—";
+  if (myRatings.length > 0) {
+    avg = `★ ${(myRatings.reduce((s, n) => s + n, 0) / myRatings.length).toFixed(1)}/5`;
+  } else if (tmdbRatings.length > 0) {
+    avg = `★ ${(tmdbRatings.reduce((s, n) => s + n, 0) / tmdbRatings.length).toFixed(1)}/10`;
+  }
+
+  setStat("total", String(movies.length));
+  setStat("week", String(week));
+  setStat("hours", `${Math.round(minutes / 60)} h`);
+  setStat("rating", avg);
+}
+
+export function renderFull(
+  main: HTMLElement,
+  movies: WatchedMovie[],
+  opts: FullOptions,
+): void {
+  const groups = new Map<string, WatchedMovie[]>();
+  for (const m of movies) {
+    const year = m.watchedDate ? String(new Date(m.watchedDate).getFullYear()) : "—";
+    if (!groups.has(year)) groups.set(year, []);
+    groups.get(year)!.push(m);
+  }
+
+  const years = [...groups.keys()].sort((a, b) => b.localeCompare(a));
+  const sections = years.map((year) => {
+    const list = el("ul", { class: "vw-list" });
+    for (const m of groups.get(year)!) list.append(fullRow(m, opts));
+    return el(
+      "section",
+      { class: "vw-year" },
+      el("h2", { class: "vw-year-label" }, year),
+      list,
+    );
+  });
+
+  main.replaceChildren(...sections);
+  updateStats(movies);
+}

--- a/src/styles/foglio.css
+++ b/src/styles/foglio.css
@@ -190,7 +190,16 @@ html.foglio,
   letter-spacing: 0;
   color: var(--foglio-ink);
 }
+.foglio-nav-right {
+  display: flex;
+  align-items: baseline;
+  gap: 1.8rem;
+}
 .foglio-nav-links {
+  display: flex;
+  gap: 1.8rem;
+}
+.foglio-nav-meta {
   display: flex;
   gap: 1.8rem;
 }
@@ -284,13 +293,24 @@ html.foglio,
 @media (max-width: 767px) {
   .foglio-nav {
     padding: 1.2rem 1.4rem;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.8rem;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    column-gap: 1rem;
+    row-gap: 0.9rem;
   }
   .foglio-nav-brand { font-size: 1.1rem; }
-  .foglio-nav-links {
+  .foglio-nav-right { display: contents; }
+  .foglio-nav-meta {
+    order: 1;
+    align-items: center;
     gap: 1.2rem;
+  }
+  .foglio-nav-links {
+    order: 2;
+    flex-basis: 100%;
+    gap: 1.4rem;
     flex-wrap: wrap;
     font-size: 0.72rem;
   }
@@ -317,6 +337,7 @@ html.foglio,
 
 @media (max-width: 767px) {
   .foglio-nav-links a,
+  .foglio-nav-meta a,
   .foglio-nav-brand,
   .ft-toggle,
   .fl-chip,


### PR DESCRIPTION
## Problema
Su mobile la nav si impilava in colonna e i link andavano a capo, spingendo il toggle tema (luna) da solo su una terza riga — header sbilenco e troppo alto.

## Soluzione
- Raggruppati i link di sezione e i controlli (lingua + tema) in due contenitori (`.foglio-nav-links`, `.foglio-nav-meta`) dentro `.foglio-nav-right`.
- Al breakpoint mobile, via `display: contents`, brand e controlli stanno sulla **riga 1** (nome a sinistra, IT + luna a destra) e i link di sezione sulla **riga 2** a tutta larghezza.
- Mantenuto il tap target da 44px anche sul link lingua (ora in `.foglio-nav-meta`).
- **Desktop invariato** (stessa spaziatura 1.8rem, stessa disposizione su una riga).

## Test
- [x] `astro check`: 0 errori
- [x] build OK, struttura nav corretta nell'HTML generato
- [ ] **Verifica visiva su mobile**: da controllare sul deploy preview (non ho browser nel sandbox per screenshot)

https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C)_