### PR TITLE
Unflag bot accidentali (DELETE /api/admin/bot + toggle UI)

### DIFF
--- a/src/pages/admin/analytics.astro
+++ b/src/pages/admin/analytics.astro
@@ -681,7 +681,10 @@ if (!isAuthorized) {
           <span class="ax-live-dot" aria-hidden="true"></span>
           Visitatori recenti
         </h2>
-        <button class="ax-bulk-flag" id="flag-all-bots">Flag zero-engagement</button>
+        <div class="ax-bulk-actions">
+          <button class="ax-bulk-flag" id="flag-all-bots">Flag zero-engagement</button>
+          <button class="ax-bulk-flag" id="unflag-recent" title="Rimuove dai bot gli hash flaggati negli ultimi 10 minuti">Annulla flag ultimi 10m</button>
+        </div>
       </div>
       <div class="ax-recent-card">
         <ul class="ax-recent" id="recent-list"><li class="ax-loading">Caricamento…</li></ul>
@@ -856,10 +859,32 @@ if (!isAuthorized) {
 
       function flagAsBot(hash, btn) {
         var row = btn.closest("li");
+        btn.disabled = true;
         fetch("/api/admin/bot", { method: "POST", headers: { "Content-Type": "application/json", "Authorization": "Bearer " + ADMIN_TOKEN }, body: JSON.stringify({ hash: hash }) })
-          .then(function(r) { if (r.ok) { row.classList.add("flagged"); btn.disabled = true; btn.textContent = "✓"; } });
+          .then(function(r) {
+            btn.disabled = false;
+            if (!r.ok) return;
+            row.classList.add("flagged");
+            btn.textContent = "↺";
+            btn.title = "Annulla flag bot";
+            btn.onclick = function() { unflagAsBot(hash, btn); };
+          });
+      }
+      function unflagAsBot(hash, btn) {
+        var row = btn.closest("li");
+        btn.disabled = true;
+        fetch("/api/admin/bot", { method: "DELETE", headers: { "Content-Type": "application/json", "Authorization": "Bearer " + ADMIN_TOKEN }, body: JSON.stringify({ hash: hash }) })
+          .then(function(r) {
+            btn.disabled = false;
+            if (!r.ok) return;
+            row.classList.remove("flagged");
+            btn.textContent = "🤖";
+            btn.title = "Flag come bot";
+            btn.onclick = function() { flagAsBot(hash, btn); };
+          });
       }
       window.flagAsBot = flagAsBot;
+      window.unflagAsBot = unflagAsBot;
 
       function flagAllBots() {
         var hashes = [];
@@ -1210,6 +1235,20 @@ if (!isAuthorized) {
       document.getElementById("nav-prev").addEventListener("click", function() { navigatePeriod(-1); });
       document.getElementById("nav-next").addEventListener("click", function() { navigatePeriod(1); });
       document.getElementById("flag-all-bots").addEventListener("click", flagAllBots);
+      document.getElementById("unflag-recent").addEventListener("click", function() {
+        var btn = document.getElementById("unflag-recent");
+        var orig = btn.textContent;
+        btn.disabled = true; btn.textContent = "Annullamento…";
+        fetch("/api/admin/bot", { method: "DELETE", headers: { "Content-Type": "application/json", "Authorization": "Bearer " + ADMIN_TOKEN }, body: JSON.stringify({ recentMinutes: 10 }) })
+          .then(function(r) { return r.json(); })
+          .then(function(d) {
+            btn.disabled = false;
+            btn.textContent = d.unflagged > 0 ? d.unflagged + " annullati" : "Nessuno da annullare";
+            setTimeout(function() { btn.textContent = orig; }, 2500);
+            loadData(currentPeriod + (currentFrom && currentTo ? "&from=" + currentFrom + "&to=" + currentTo : ""));
+          })
+          .catch(function() { btn.disabled = false; btn.textContent = "Errore"; setTimeout(function() { btn.textContent = orig; }, 2500); });
+      });
       document.getElementById("flag-suspects-btn").addEventListener("click", function() {
         var btn = document.getElementById("flag-suspects-btn");
         if (!currentFrom || !currentTo) return;

--- a/src/pages/api/admin/bot.ts
+++ b/src/pages/api/admin/bot.ts
@@ -19,6 +19,11 @@ type BotAction =
   | { type: "bulkHash"; hashes: string[] }
   | { type: "singleHash"; hash: string };
 
+type BotUnflagAction =
+  | { type: "unflagHash"; hash: string }
+  | { type: "unflagHashes"; hashes: string[] }
+  | { type: "unflagRecent"; minutes: number };
+
 function parseBotAction(body: unknown): Result<BotAction> {
   if (!body || typeof body !== "object") return err("Invalid body");
   const b = body as Record<string, unknown>;
@@ -44,6 +49,32 @@ function parseBotAction(body: unknown): Result<BotAction> {
   return err("Invalid hash");
 }
 
+function parseBotUnflagAction(body: unknown): Result<BotUnflagAction> {
+  if (!body || typeof body !== "object") return err("Invalid body");
+  const b = body as Record<string, unknown>;
+
+  if (typeof b.recentMinutes === "number") {
+    const n = Math.floor(b.recentMinutes);
+    if (!Number.isFinite(n) || n <= 0 || n > 1440)
+      return err("recentMinutes must be 1..1440");
+    return ok({ type: "unflagRecent", minutes: n });
+  }
+
+  if (Array.isArray(b.hashes)) {
+    const valid = b.hashes.filter(
+      (h: unknown) => typeof h === "string" && h.length > 0 && h.length <= 32,
+    );
+    if (valid.length === 0) return err("No valid hashes");
+    return ok({ type: "unflagHashes", hashes: valid });
+  }
+
+  if (typeof b.hash === "string" && b.hash.length > 0 && b.hash.length <= 32) {
+    return ok({ type: "unflagHash", hash: b.hash });
+  }
+
+  return err("Invalid input");
+}
+
 async function recalcUniqueForHashes(
   db: ReturnType<typeof getDb>,
   hashes: string[],
@@ -51,6 +82,26 @@ async function recalcUniqueForHashes(
   for (const h of hashes) {
     await db.execute({
       sql: "UPDATE pageviews SET is_unique = 0 WHERE visitor_hash = ?",
+      args: [h],
+    });
+  }
+}
+
+async function restoreUniqueForHashes(
+  db: ReturnType<typeof getDb>,
+  hashes: string[],
+) {
+  for (const h of hashes) {
+    await db.execute({
+      sql: `UPDATE pageviews
+            SET is_unique = CASE WHEN id = (
+              SELECT p2.id FROM pageviews p2
+              WHERE p2.visitor_hash = pageviews.visitor_hash
+                AND date(p2.created_at) = date(pageviews.created_at)
+              ORDER BY p2.created_at ASC, p2.id ASC
+              LIMIT 1
+            ) THEN 1 ELSE 0 END
+            WHERE visitor_hash = ?`,
       args: [h],
     });
   }
@@ -67,6 +118,19 @@ async function insertAndRecalc(
   });
   await recalcUniqueForHashes(db, hashes);
   return jsonOk({ ok: true, flagged: hashes.length });
+}
+
+async function deleteAndRestore(
+  db: ReturnType<typeof getDb>,
+  hashes: string[],
+): Promise<Response> {
+  const placeholders = hashes.map(() => "?").join(",");
+  await db.execute({
+    sql: `DELETE FROM bot_hashes WHERE hash IN (${placeholders})`,
+    args: hashes,
+  });
+  await restoreUniqueForHashes(db, hashes);
+  return jsonOk({ ok: true, unflagged: hashes.length });
 }
 
 export const POST: APIRoute = async ({ request }) => {
@@ -98,4 +162,42 @@ export const POST: APIRoute = async ({ request }) => {
   }
 
   return insertAndRecalc(db, [action.hash]);
+};
+
+export const DELETE: APIRoute = async ({ request }) => {
+  if (!verifyBearerToken(request, env("ADMIN_TOKEN"))) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const bodyResult = await parseJsonBody(request);
+  if (!bodyResult.ok) return jsonErr(bodyResult.error, 400);
+
+  const parsed = parseBotUnflagAction(bodyResult.value);
+  if (!parsed.ok) return jsonErr(parsed.error, 400);
+
+  const db = getDb();
+  const action = parsed.value;
+
+  if (action.type === "unflagRecent") {
+    const cutoff = new Date(Date.now() - action.minutes * 60 * 1000)
+      .toISOString()
+      .slice(0, 19)
+      .replace("T", " ");
+    const recent = await db.execute({
+      sql: "SELECT hash FROM bot_hashes WHERE created_at >= ?",
+      args: [cutoff],
+    });
+    const hashes = recent.rows.map((r) => String(r.hash));
+    if (hashes.length === 0) return jsonOk({ ok: true, unflagged: 0 });
+    return deleteAndRestore(db, hashes);
+  }
+
+  if (action.type === "unflagHashes") {
+    return deleteAndRestore(db, action.hashes);
+  }
+
+  return deleteAndRestore(db, [action.hash]);
 };


### PR DESCRIPTION
## Contesto
Il flag bot era a senso unico: una volta flaggato un visitor, l'unico rollback era accedere al DB. È capitato di flaggare per sbaglio visite valide cliccando l'icona 🤖.

## Soluzione
- **`DELETE /api/admin/bot`**: nuovo handler che accetta `{ hash }`, `{ hashes }` o `{ recentMinutes }` (1..1440).
- **Restore `is_unique`** deterministico dopo l'unflag: 1 per il primo pageview di ogni giorno per quel `visitor_hash`, 0 per gli altri (stessa logica usata all'INSERT).
- **UI**: nuovo bottone "Annulla flag ultimi 10m" accanto a "Flag zero-engagement"; il bottone per-riga ora si trasforma in toggle ↺ dopo il flag, così è reversibile in sessione.

## Test
- [x] `astro check`: 0 errori
- [x] Pre-commit hook (vitest related) verde
- [ ] Verifica funzionale: dopo il merge, dalla dashboard `/admin/analytics` cliccare "Annulla flag ultimi 10m" per recuperare i due flag accidentali

https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C)_