### PR TITLE
Allarga finestra bulk-unflag a 24h

### DIFF
--- a/src/pages/admin/analytics.astro
+++ b/src/pages/admin/analytics.astro
@@ -683,7 +683,7 @@ if (!isAuthorized) {
         </h2>
         <div class="ax-bulk-actions">
           <button class="ax-bulk-flag" id="flag-all-bots">Flag zero-engagement</button>
-          <button class="ax-bulk-flag" id="unflag-recent" title="Rimuove dai bot gli hash flaggati negli ultimi 10 minuti">Annulla flag ultimi 10m</button>
+          <button class="ax-bulk-flag" id="unflag-recent" title="Rimuove dai bot gli hash flaggati nelle ultime 24 ore">Annulla flag fatti oggi</button>
         </div>
       </div>
       <div class="ax-recent-card">
@@ -1239,7 +1239,7 @@ if (!isAuthorized) {
         var btn = document.getElementById("unflag-recent");
         var orig = btn.textContent;
         btn.disabled = true; btn.textContent = "Annullamento…";
-        fetch("/api/admin/bot", { method: "DELETE", headers: { "Content-Type": "application/json", "Authorization": "Bearer " + ADMIN_TOKEN }, body: JSON.stringify({ recentMinutes: 10 }) })
+        fetch("/api/admin/bot", { method: "DELETE", headers: { "Content-Type": "application/json", "Authorization": "Bearer " + ADMIN_TOKEN }, body: JSON.stringify({ recentMinutes: 1440 }) })
           .then(function(r) { return r.json(); })
           .then(function(d) {
             btn.disabled = false;


### PR DESCRIPTION
## Problema
La finestra di 10 minuti del bottone "Annulla flag ultimi 10m" era troppo stretta: un flag accidentale fatto qualche ora prima non veniva annullato (l'endpoint trovava 0 hash recenti), lasciando la dashboard a 0 visite.

## Fix
- Estesa la finestra a **1440 minuti (24h)**, sufficiente a coprire tutti i flag fatti nello stesso giorno.
- Bottone rinominato in **"Annulla flag fatti oggi"** per riflettere il comportamento.
- Il toggle per-riga (🤖 → ↺ dopo flag) resta come reversibilità immediata in sessione.

## Test
- [x] `astro check`: 0 errori

https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C)_