### PR TITLE
Annulla TUTTI i flag (paracadute) + test round-trip

### DIFF
--- a/src/lib/bot-rollback.test.ts
+++ b/src/lib/bot-rollback.test.ts
@@ -1,0 +1,162 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { createClient, type Client } from "@libsql/client";
+
+let db: Client;
+
+vi.mock("~/lib/turso", () => ({
+  default: () => db,
+}));
+
+vi.mock("~/lib/env", () => ({
+  env: (key: string) => (key === "ADMIN_TOKEN" ? "test-token" : ""),
+}));
+
+const { POST, DELETE } = await import("~/pages/api/admin/bot");
+
+async function seedDb() {
+  await db.executeMultiple(`
+    CREATE TABLE pageviews (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      page_id TEXT NOT NULL,
+      hostname TEXT NOT NULL,
+      pathname TEXT NOT NULL,
+      is_unique INTEGER NOT NULL DEFAULT 0,
+      visitor_hash TEXT,
+      time_on_page INTEGER,
+      scroll_depth INTEGER,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE bot_hashes (
+      hash TEXT PRIMARY KEY,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+}
+
+async function insertPv(opts: {
+  hash: string;
+  pathname?: string;
+  is_unique?: number;
+  created_at?: string;
+}) {
+  await db.execute({
+    sql: `INSERT INTO pageviews (page_id, hostname, pathname, is_unique, visitor_hash, created_at)
+          VALUES (?, ?, ?, ?, ?, COALESCE(?, datetime('now')))`,
+    args: [
+      Math.random().toString(36).slice(2, 10),
+      "valerionarcisi.me",
+      opts.pathname ?? "/",
+      opts.is_unique ?? 0,
+      opts.hash,
+      opts.created_at ?? null,
+    ],
+  });
+}
+
+async function statsCount() {
+  const r = await db.execute({
+    sql: `SELECT COUNT(*) AS pageviews, SUM(is_unique) AS visitors
+          FROM pageviews
+          WHERE visitor_hash IS NULL OR visitor_hash NOT IN (SELECT hash FROM bot_hashes)`,
+    args: [],
+  });
+  return {
+    pageviews: Number(r.rows[0].pageviews) || 0,
+    visitors: Number(r.rows[0].visitors) || 0,
+  };
+}
+
+function req(method: "POST" | "DELETE", body: unknown) {
+  return new Request("http://x/api/admin/bot", {
+    method,
+    headers: {
+      "Authorization": "Bearer test-token",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("bot flag + rollback round-trip", () => {
+  beforeEach(async () => {
+    db = createClient({ url: ":memory:" });
+    await seedDb();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  test("matches the user scenario: 4 pageviews / 2 visitors → flag both → 0/0 → unflag → back to 4/2", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    // h1 visited twice today, first row is_unique=1
+    await insertPv({ hash: "h1", is_unique: 1, created_at: `${today} 08:00:00` });
+    await insertPv({ hash: "h1", is_unique: 0, created_at: `${today} 09:00:00` });
+    // h2 visited twice today, first row is_unique=1
+    await insertPv({ hash: "h2", is_unique: 1, created_at: `${today} 10:00:00` });
+    await insertPv({ hash: "h2", is_unique: 0, created_at: `${today} 11:00:00` });
+
+    expect(await statsCount()).toEqual({ pageviews: 4, visitors: 2 });
+
+    // user flags both visitors (one at a time, like the UI does)
+    const r1 = await POST({ request: req("POST", { hash: "h1" }) } as any);
+    expect(r1.status).toBe(200);
+    const r2 = await POST({ request: req("POST", { hash: "h2" }) } as any);
+    expect(r2.status).toBe(200);
+
+    // both excluded, stats go to 0/0
+    expect(await statsCount()).toEqual({ pageviews: 0, visitors: 0 });
+
+    // user clicks "Annulla flag fatti oggi" (24h window)
+    const u = await DELETE!({ request: req("DELETE", { recentMinutes: 1440 }) } as any);
+    expect(u.status).toBe(200);
+    const json = await u.json();
+    expect(json.unflagged).toBe(2);
+
+    // stats should be restored to 4 pageviews / 2 visitors
+    expect(await statsCount()).toEqual({ pageviews: 4, visitors: 2 });
+  });
+
+  test("{ all: true } removes every flagged hash regardless of timestamp", async () => {
+    await insertPv({ hash: "old", is_unique: 1 });
+    await insertPv({ hash: "fresh", is_unique: 1 });
+    await db.execute({
+      sql: "INSERT INTO bot_hashes (hash, created_at) VALUES (?, datetime('now', '-5 days'))",
+      args: ["old"],
+    });
+    await POST({ request: req("POST", { hash: "fresh" }) } as any);
+    expect(await statsCount()).toEqual({ pageviews: 0, visitors: 0 });
+
+    const u = await DELETE!({ request: req("DELETE", { all: true }) } as any);
+    const json = await u.json();
+    expect(json.unflagged).toBe(2);
+    expect(await statsCount()).toEqual({ pageviews: 2, visitors: 2 });
+  });
+
+  test("recentMinutes window only catches recently flagged hashes", async () => {
+    await insertPv({ hash: "old", is_unique: 1 });
+    await insertPv({ hash: "fresh", is_unique: 1 });
+
+    // simulate an OLD flag (2 days ago) by inserting directly with backdated created_at
+    await db.execute({
+      sql: "INSERT INTO bot_hashes (hash, created_at) VALUES (?, datetime('now', '-2 days'))",
+      args: ["old"],
+    });
+    // and a fresh flag now (via the endpoint)
+    await POST({ request: req("POST", { hash: "fresh" }) } as any);
+
+    expect(await statsCount()).toEqual({ pageviews: 0, visitors: 0 });
+
+    // 24h window: should only unflag "fresh", not "old"
+    const u = await DELETE!({
+      request: req("DELETE", { recentMinutes: 1440 }),
+    } as any);
+    const json = await u.json();
+    expect(json.unflagged).toBe(1);
+
+    // "fresh" restored, "old" still flagged
+    const stats = await statsCount();
+    expect(stats.pageviews).toBe(1);
+    expect(stats.visitors).toBe(1);
+  });
+});

--- a/src/pages/admin/analytics.astro
+++ b/src/pages/admin/analytics.astro
@@ -684,6 +684,7 @@ if (!isAuthorized) {
         <div class="ax-bulk-actions">
           <button class="ax-bulk-flag" id="flag-all-bots">Flag zero-engagement</button>
           <button class="ax-bulk-flag" id="unflag-recent" title="Rimuove dai bot gli hash flaggati nelle ultime 24 ore">Annulla flag fatti oggi</button>
+          <button class="ax-bulk-flag" id="unflag-all" title="Rimuove TUTTI gli hash dalla bot list (paracadute)">Annulla TUTTI</button>
         </div>
       </div>
       <div class="ax-recent-card">
@@ -1235,6 +1236,21 @@ if (!isAuthorized) {
       document.getElementById("nav-prev").addEventListener("click", function() { navigatePeriod(-1); });
       document.getElementById("nav-next").addEventListener("click", function() { navigatePeriod(1); });
       document.getElementById("flag-all-bots").addEventListener("click", flagAllBots);
+      document.getElementById("unflag-all").addEventListener("click", function() {
+        if (!confirm("Rimuovere TUTTI gli hash flaggati come bot? L'azione ricalcolerà is_unique per ogni hash.")) return;
+        var btn = document.getElementById("unflag-all");
+        var orig = btn.textContent;
+        btn.disabled = true; btn.textContent = "Annullamento…";
+        fetch("/api/admin/bot?_=" + Date.now(), { method: "DELETE", headers: { "Content-Type": "application/json", "Authorization": "Bearer " + ADMIN_TOKEN }, body: JSON.stringify({ all: true }) })
+          .then(function(r) { return r.json(); })
+          .then(function(d) {
+            btn.disabled = false;
+            btn.textContent = d.unflagged > 0 ? d.unflagged + " annullati" : "Nessuno da annullare";
+            setTimeout(function() { btn.textContent = orig; }, 3000);
+            loadData(currentPeriod + (currentFrom && currentTo ? "&from=" + currentFrom + "&to=" + currentTo : ""));
+          })
+          .catch(function() { btn.disabled = false; btn.textContent = "Errore"; setTimeout(function() { btn.textContent = orig; }, 3000); });
+      });
       document.getElementById("unflag-recent").addEventListener("click", function() {
         var btn = document.getElementById("unflag-recent");
         var orig = btn.textContent;

--- a/src/pages/api/admin/bot.ts
+++ b/src/pages/api/admin/bot.ts
@@ -22,7 +22,8 @@ type BotAction =
 type BotUnflagAction =
   | { type: "unflagHash"; hash: string }
   | { type: "unflagHashes"; hashes: string[] }
-  | { type: "unflagRecent"; minutes: number };
+  | { type: "unflagRecent"; minutes: number }
+  | { type: "unflagAll" };
 
 function parseBotAction(body: unknown): Result<BotAction> {
   if (!body || typeof body !== "object") return err("Invalid body");
@@ -52,6 +53,10 @@ function parseBotAction(body: unknown): Result<BotAction> {
 function parseBotUnflagAction(body: unknown): Result<BotUnflagAction> {
   if (!body || typeof body !== "object") return err("Invalid body");
   const b = body as Record<string, unknown>;
+
+  if (b.all === true) {
+    return ok({ type: "unflagAll" });
+  }
 
   if (typeof b.recentMinutes === "number") {
     const n = Math.floor(b.recentMinutes);
@@ -180,6 +185,16 @@ export const DELETE: APIRoute = async ({ request }) => {
 
   const db = getDb();
   const action = parsed.value;
+
+  if (action.type === "unflagAll") {
+    const all = await db.execute({
+      sql: "SELECT hash FROM bot_hashes",
+      args: [],
+    });
+    const hashes = all.rows.map((r) => String(r.hash));
+    if (hashes.length === 0) return jsonOk({ ok: true, unflagged: 0 });
+    return deleteAndRestore(db, hashes);
+  }
 
   if (action.type === "unflagRecent") {
     const cutoff = new Date(Date.now() - action.minutes * 60 * 1000)


### PR DESCRIPTION
## Contesto
Dopo PR #15/#16 il rollback bulk si è rivelato fragile in produzione: cliccando "Annulla flag fatti oggi" le visite sono restate a 0 (probabilmente cache della pagina admin o tempistica del deploy). Servono due cose: un paracadute definitivo che bypassi qualunque finestra temporale, e prove robuste che la SQL di restore funzioni davvero.

## Modifiche
- **Endpoint**: aggiunta variante `{ all: true }` su `DELETE /api/admin/bot` — rimuove TUTTI gli hash da `bot_hashes` e richiama il restore deterministico di `is_unique`.
- **UI**: nuovo bottone "Annulla TUTTI" con `confirm()`, e cache-busting query string (`?_=Date.now()`) sulla DELETE per evitare risposte stale di CDN/browser.
- **Test** (`src/lib/bot-rollback.test.ts`): 3 round-trip su libsql in memoria che riproducono lo scenario reale (4 pageviews / 2 visitatori → flag entrambi → 0/0 → unflag → 4/2) e coprono sia `recentMinutes` sia `{ all: true }`.

## Test
- [x] `astro check`: 0 errori
- [x] vitest: 3/3 round-trip passano

## Per il rollback immediato (uso del paracadute)
Dopo il merge e il deploy: hard refresh della pagina admin → click su **"Annulla TUTTI"** → conferma. Le 2 visite torneranno a 4/2.

https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C)_