### PR TITLE
fix(admin): rendi visibili i bottoni di unflag

### DIFF
--- a/src/pages/admin/analytics.astro
+++ b/src/pages/admin/analytics.astro
@@ -552,8 +552,8 @@ if (!isAuthorized) {
         border: 1px solid var(--ax-neg);
         border-radius: var(--foglio-radius-sm);
         cursor: pointer;
-        display: none;
       }
+      .foglio body.admin #flag-all-bots { display: none; }
       .foglio body.admin .ax-bulk-flag:hover { background: var(--ax-neg); color: var(--foglio-paper); }
 
       .foglio body.admin .ax-loading,


### PR DESCRIPTION
## Bug trovato
I bottoni nuovi ("Annulla flag fatti oggi", "Annulla TUTTI") avevano la stessa classe `.ax-bulk-flag` di "Flag zero-engagement", e quella classe ha `display: none` di default. Il JS sblocca la visibilità SOLO per `#flag-all-bots` quando ci sono visitatori a basso engagement. Le mie due nuove non venivano mai sbloccate → invisibili per sempre. Ecco perché cliccarle non recuperava le visite: non venivano mai cliccate, semplicemente non si vedevano.

## Fix
Scopo il `display: none` a `#flag-all-bots` invece che a `.ax-bulk-flag` in generale. Gli altri bottoni con quella classe restano visibili. La toggle in JS continua a funzionare (gli `inline-block`/`none` inline sovrascrivono lo style del selettore).

## Test
- [x] `astro check`: 0 errori

## Recupero dati
Indipendentemente da questo deploy, l'endpoint `DELETE /api/admin/bot {all:true}` è live dal PR #17 e si può chiamare via Console DevTools per recuperare subito le visite flaggate per sbaglio.

https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C)_