### PR TITLE
URL tap-to-recover per unflag totale da mobile

### DIFF
--- a/src/pages/api/admin/bot.ts
+++ b/src/pages/api/admin/bot.ts
@@ -216,3 +216,55 @@ export const DELETE: APIRoute = async ({ request }) => {
 
   return deleteAndRestore(db, [action.hash]);
 };
+
+export const GET: APIRoute = async ({ request, url }) => {
+  const token = url.searchParams.get("token") ?? "";
+  if (token !== env("ADMIN_TOKEN") || token.length === 0) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const action = url.searchParams.get("recover");
+  if (action !== "all") {
+    return new Response(
+      "Usage: GET /api/admin/bot?recover=all&token=ADMIN_TOKEN",
+      { status: 400, headers: { "Content-Type": "text/plain" } },
+    );
+  }
+
+  const db = getDb();
+  const all = await db.execute({
+    sql: "SELECT hash FROM bot_hashes",
+    args: [],
+  });
+  const hashes = all.rows.map((r) => String(r.hash));
+  if (hashes.length === 0) {
+    return new Response(
+      `<!doctype html><meta charset="utf-8"><title>Recover</title><body style="font-family:system-ui;padding:2rem;max-width:600px"><h1>Nothing to unflag</h1><p>bot_hashes è vuota.</p><p><a href="/admin/analytics?token=${token}">→ Torna alla dashboard</a></p></body>`,
+      { status: 200, headers: { "Content-Type": "text/html; charset=utf-8" } },
+    );
+  }
+
+  await db.execute({
+    sql: `DELETE FROM bot_hashes WHERE hash IN (${hashes.map(() => "?").join(",")})`,
+    args: hashes,
+  });
+  for (const h of hashes) {
+    await db.execute({
+      sql: `UPDATE pageviews
+            SET is_unique = CASE WHEN id = (
+              SELECT p2.id FROM pageviews p2
+              WHERE p2.visitor_hash = pageviews.visitor_hash
+                AND date(p2.created_at) = date(pageviews.created_at)
+              ORDER BY p2.created_at ASC, p2.id ASC
+              LIMIT 1
+            ) THEN 1 ELSE 0 END
+            WHERE visitor_hash = ?`,
+      args: [h],
+    });
+  }
+
+  return new Response(
+    `<!doctype html><meta charset="utf-8"><title>Recover</title><body style="font-family:system-ui;padding:2rem;max-width:600px"><h1>OK — ${hashes.length} hash sbloccati</h1><p>bot_hashes svuotata, is_unique ricalcolato.</p><p><a href="/admin/analytics?token=${token}">→ Torna alla dashboard</a></p></body>`,
+    { status: 200, headers: { "Content-Type": "text/html; charset=utf-8" } },
+  );
+};


### PR DESCRIPTION
## Contesto
Su mobile non c'è DevTools, quindi lo snippet `fetch(...)` per chiamare `DELETE /api/admin/bot { all: true }` non è incollabile in Console. Serve un'azione attivabile tappando una URL.

## Soluzione
Nuovo handler `GET /api/admin/bot?recover=all&token=ADMIN_TOKEN`:
- Auth via query string (stesso pattern di `/admin/*`).
- Svuota `bot_hashes` e ricalcola `is_unique` con la stessa logica deterministica del `DELETE { all: true }`.
- Risponde con HTML minimale che conferma il numero di hash sbloccati e linka alla dashboard.

## Test
- [x] `astro check`: 0 errori
- [x] vitest pre-commit verde

## Per il recupero immediato
Dopo il deploy, basta aprire:
```
https://valerionarcisi.me/api/admin/bot?recover=all&token=ADMIN_TOKEN
```

https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C)_