### PR TITLE
fix(footer): link social 404 (LinkedIn + Letterboxd fix, BlueSky + IG rimossi)

### DIFF
--- a/src/components/FoglioFooter.astro
+++ b/src/components/FoglioFooter.astro
@@ -11,9 +11,8 @@ const year = new Date().getFullYear();
   <div class="foglio-footer-inner">
     <div>© {year} Valerio Narcisi · Porto Sant'Elpidio</div>
     <div class="foglio-footer-social">
-      <a href="https://www.instagram.com/narcisi.valerio/" target="_blank" rel="noopener">Instagram</a>
-      <a href="https://www.linkedin.com/in/valerionarcisi/" target="_blank" rel="noopener">LinkedIn</a>
-      <a href="https://boxd.it/2mFff" target="_blank" rel="noopener">Letterboxd</a>
+      <a href="https://www.linkedin.com/in/cv-valerio-narcisi/" target="_blank" rel="noopener">LinkedIn</a>
+      <a href="https://letterboxd.com/valenar/" target="_blank" rel="noopener">Letterboxd</a>
       <a href="https://github.com/valerionarcisi" target="_blank" rel="noopener">GitHub</a>
       <a href={lang === "en" ? "/en/rss.xml" : "/rss.xml"}>RSS</a>
     </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -11,11 +11,6 @@ const today = new Date();
         <a href="mailto:valerio.narcisi@gmail.com">valerio.narcisi@gmail.com</a>
       </li>
       <li>
-        <a target="_blank" href="https://www.instagram.com/narcisi.valerio/"
-          >Instagram</a
-        >
-      </li>
-      <li>
         <a target="_blank" href="https://github.com/valerionarcisi">Github</a>
       </li>
       <li>
@@ -25,12 +20,7 @@ const today = new Date();
         >
       </li>
       <li>
-        <a target="_blank" href="https://bsky.app/profile/valerionarcisi.me"
-          >BlueSky</a
-        >
-      </li>
-      <li>
-        <a target="_blank" href="https://boxd.it/2mFff">Letterboxd</a>
+        <a target="_blank" href="https://letterboxd.com/valenar/">Letterboxd</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
## Fix
Link social nei footer che davano 404:

| Piattaforma | Prima | Dopo |
|---|---|---|
| LinkedIn | `/in/valerionarcisi/` | `/in/cv-valerio-narcisi/` (funzionante, era già in Footer legacy) |
| Letterboxd | `boxd.it/2mFff` (short URL morta) | `letterboxd.com/valenar/` (username già usata dall'RSS in `src/services/letterboxd.ts`) |
| BlueSky | `bsky.app/profile/valerionarcisi.me` | **rimosso** (404, niente handle alternativa) |
| Instagram | `narcisi.valerio` | **rimosso** (404, handle dimenticata) |

Modificati sia `FoglioFooter.astro` (design attuale) che `Footer.astro` (legacy) per coerenza.

## Quando recuperi le handle giuste
- Instagram: dimmi la handle e te la rimetto in 5 sec.
- BlueSky: idem.

## Test
- [x] `astro check`: 0 errori

https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C)_