### PR TITLE
fix(footer): BlueSky restored con handle vecchia che funzionava

### DIFF
--- a/src/components/FoglioFooter.astro
+++ b/src/components/FoglioFooter.astro
@@ -13,6 +13,7 @@ const year = new Date().getFullYear();
     <div class="foglio-footer-social">
       <a href="https://www.linkedin.com/in/cv-valerio-narcisi/" target="_blank" rel="noopener">LinkedIn</a>
       <a href="https://letterboxd.com/valenar/" target="_blank" rel="noopener">Letterboxd</a>
+      <a href="https://bsky.app/profile/valnar.bsky.social" target="_blank" rel="noopener">BlueSky</a>
       <a href="https://github.com/valerionarcisi" target="_blank" rel="noopener">GitHub</a>
       <a href={lang === "en" ? "/en/rss.xml" : "/rss.xml"}>RSS</a>
     </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -22,6 +22,11 @@ const today = new Date();
       <li>
         <a target="_blank" href="https://letterboxd.com/valenar/">Letterboxd</a>
       </li>
+      <li>
+        <a target="_blank" href="https://bsky.app/profile/valnar.bsky.social"
+          >BlueSky</a
+        >
+      </li>
     </ul>
   </div>
   <div>


### PR DESCRIPTION
## Cosa ho trovato nei commit vecchi
- **BlueSky**: `valnar.bsky.social` era la handle originale nel repo, poi swappata in `valerionarcisi.me` (custom domain) che però 404 — probabilmente verifica DNS non completata. **Rollback alla handle originale.**
- **Instagram**: nello storico esiste solo `narcisi.valerio` (la rotta). Nessuna altra handle è mai stata committata. Resta rimossa finché non recuperi l'handle giusta.

## Diff
| | Prima (PR #22) | Dopo |
|---|---|---|
| BlueSky FoglioFooter | rimosso | `bsky.app/profile/valnar.bsky.social` |
| BlueSky Footer (legacy) | rimosso | `bsky.app/profile/valnar.bsky.social` |
| Instagram | rimosso | rimosso (nessun fix disponibile) |

## Test
- [x] `astro check`: 0 errori
- [ ] Verifica manuale dopo deploy: tappa il link BlueSky → dovrebbe portare al profilo

Se `valnar.bsky.social` 404 anche lui, fammi sapere — magari l'account è stato cancellato e basta toglierlo.

https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C)_