### PR TITLE
fix(footer): ripristina Instagram + BlueSky custom domain

### DIFF
--- a/src/components/FoglioFooter.astro
+++ b/src/components/FoglioFooter.astro
@@ -11,9 +11,10 @@ const year = new Date().getFullYear();
   <div class="foglio-footer-inner">
     <div>© {year} Valerio Narcisi · Porto Sant'Elpidio</div>
     <div class="foglio-footer-social">
+      <a href="https://www.instagram.com/narcisi.valerio/" target="_blank" rel="noopener">Instagram</a>
       <a href="https://www.linkedin.com/in/cv-valerio-narcisi/" target="_blank" rel="noopener">LinkedIn</a>
       <a href="https://letterboxd.com/valenar/" target="_blank" rel="noopener">Letterboxd</a>
-      <a href="https://bsky.app/profile/valnar.bsky.social" target="_blank" rel="noopener">BlueSky</a>
+      <a href="https://bsky.app/profile/valerionarcisi.me" target="_blank" rel="noopener">BlueSky</a>
       <a href="https://github.com/valerionarcisi" target="_blank" rel="noopener">GitHub</a>
       <a href={lang === "en" ? "/en/rss.xml" : "/rss.xml"}>RSS</a>
     </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -11,6 +11,11 @@ const today = new Date();
         <a href="mailto:valerio.narcisi@gmail.com">valerio.narcisi@gmail.com</a>
       </li>
       <li>
+        <a target="_blank" href="https://www.instagram.com/narcisi.valerio/"
+          >Instagram</a
+        >
+      </li>
+      <li>
         <a target="_blank" href="https://github.com/valerionarcisi">Github</a>
       </li>
       <li>
@@ -23,7 +28,7 @@ const today = new Date();
         <a target="_blank" href="https://letterboxd.com/valenar/">Letterboxd</a>
       </li>
       <li>
-        <a target="_blank" href="https://bsky.app/profile/valnar.bsky.social"
+        <a target="_blank" href="https://bsky.app/profile/valerionarcisi.me"
           >BlueSky</a
         >
       </li>


### PR DESCRIPTION
## Cosa cambia
Confermato dall'utente:
- IG handle è davvero `narcisi.valerio` (rimossa per errore in PR #22)
- BlueSky usa il custom domain `valerionarcisi.me` (non `valnar.bsky.social`)

Ripristino entrambi i link in `FoglioFooter.astro` e `Footer.astro`.

## Footer finale (FoglioFooter)
Instagram · LinkedIn · Letterboxd · BlueSky · GitHub · RSS

## Se ancora 404 al tap
- **BlueSky** `valerionarcisi.me`: verifica DNS TXT `_atproto.valerionarcisi.me` punti al DID corretto, oppure rifai la handle verification dalle settings di Bluesky.
- **Instagram** `narcisi.valerio`: controlla che l'account sia ancora attivo dal tuo profilo IG.

In entrambi i casi è issue lato piattaforma, non lato sito.

## Test
- [x] `astro check`: 0 errori

https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C)_