### PR TITLE
fix(contatti): allinea social IT + EN ai link corretti del footer

### DIFF
--- a/src/pages/contatti.astro
+++ b/src/pages/contatti.astro
@@ -31,21 +31,33 @@ import { SITE_TITLE } from "~/consts";
         <h2 class="ct-block-label">Altrove</h2>
         <ul class="ct-links">
           <li>
-            <span class="ct-link-role">GitHub</span>
-            <a href="https://github.com/valerionarcisi" class="ct-link" target="_blank" rel="noopener noreferrer">
-              github.com/valerionarcisi
+            <span class="ct-link-role">Instagram</span>
+            <a href="https://www.instagram.com/narcisi.valerio/" class="ct-link" target="_blank" rel="noopener noreferrer">
+              instagram.com/narcisi.valerio
             </a>
           </li>
           <li>
             <span class="ct-link-role">LinkedIn</span>
-            <a href="https://www.linkedin.com/in/valerionarcisi/" class="ct-link" target="_blank" rel="noopener noreferrer">
-              linkedin.com/in/valerionarcisi
+            <a href="https://www.linkedin.com/in/cv-valerio-narcisi/" class="ct-link" target="_blank" rel="noopener noreferrer">
+              linkedin.com/in/cv-valerio-narcisi
             </a>
           </li>
           <li>
             <span class="ct-link-role">Letterboxd</span>
-            <a href="https://letterboxd.com/valerionarcisi/" class="ct-link" target="_blank" rel="noopener noreferrer">
-              letterboxd.com/valerionarcisi
+            <a href="https://letterboxd.com/valenar/" class="ct-link" target="_blank" rel="noopener noreferrer">
+              letterboxd.com/valenar
+            </a>
+          </li>
+          <li>
+            <span class="ct-link-role">BlueSky</span>
+            <a href="https://bsky.app/profile/valerionarcisi.me" class="ct-link" target="_blank" rel="noopener noreferrer">
+              bsky.app/valerionarcisi.me
+            </a>
+          </li>
+          <li>
+            <span class="ct-link-role">GitHub</span>
+            <a href="https://github.com/valerionarcisi" class="ct-link" target="_blank" rel="noopener noreferrer">
+              github.com/valerionarcisi
             </a>
           </li>
         </ul>

--- a/src/pages/en/contact.astro
+++ b/src/pages/en/contact.astro
@@ -31,21 +31,33 @@ import { SITE_TITLE } from "~/consts";
         <h2 class="ct-block-label">Elsewhere</h2>
         <ul class="ct-links">
           <li>
-            <span class="ct-link-role">GitHub</span>
-            <a href="https://github.com/valerionarcisi" class="ct-link" target="_blank" rel="noopener noreferrer">
-              github.com/valerionarcisi
+            <span class="ct-link-role">Instagram</span>
+            <a href="https://www.instagram.com/narcisi.valerio/" class="ct-link" target="_blank" rel="noopener noreferrer">
+              instagram.com/narcisi.valerio
             </a>
           </li>
           <li>
             <span class="ct-link-role">LinkedIn</span>
-            <a href="https://www.linkedin.com/in/valerionarcisi/" class="ct-link" target="_blank" rel="noopener noreferrer">
-              linkedin.com/in/valerionarcisi
+            <a href="https://www.linkedin.com/in/cv-valerio-narcisi/" class="ct-link" target="_blank" rel="noopener noreferrer">
+              linkedin.com/in/cv-valerio-narcisi
             </a>
           </li>
           <li>
             <span class="ct-link-role">Letterboxd</span>
-            <a href="https://letterboxd.com/valerionarcisi/" class="ct-link" target="_blank" rel="noopener noreferrer">
-              letterboxd.com/valerionarcisi
+            <a href="https://letterboxd.com/valenar/" class="ct-link" target="_blank" rel="noopener noreferrer">
+              letterboxd.com/valenar
+            </a>
+          </li>
+          <li>
+            <span class="ct-link-role">BlueSky</span>
+            <a href="https://bsky.app/profile/valerionarcisi.me" class="ct-link" target="_blank" rel="noopener noreferrer">
+              bsky.app/valerionarcisi.me
+            </a>
+          </li>
+          <li>
+            <span class="ct-link-role">GitHub</span>
+            <a href="https://github.com/valerionarcisi" class="ct-link" target="_blank" rel="noopener noreferrer">
+              github.com/valerionarcisi
             </a>
           </li>
         </ul>


### PR DESCRIPTION
## Cambio
La pagina `/contatti` aveva URL stale che 404:
- LinkedIn: `/in/valerionarcisi/` → `/in/cv-valerio-narcisi/`
- Letterboxd: `/valerionarcisi/` → `/valenar/`

Aggiunti anche **Instagram** (`narcisi.valerio`) e **BlueSky** (`valerionarcisi.me`) per coerenza con il footer.

Stesso fix sulla pagina inglese `/en/contact`.

## Test
- [x] `astro check`: 0 errori

https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C)_