### PR TITLE
feat(meal-plan): pesi da cotto per riso e pasta nei pasti giornalieri

### DIFF
--- a/src/data/meal-plan.ts
+++ b/src/data/meal-plan.ts
@@ -151,7 +151,7 @@ export const days: DayPlan[] = [
           {
             oil: "3 cucchiaini olio EVO a crudo",
             items: [
-              "120g riso basmati (cotto ~300g) o pasta al dente (cotta ~240g) o altro cereale (miglio, grano saraceno, quinoa, amaranto, sorgo, teff, cous cous) condito con verdure di stagione in abbondanza + circa 100g fonte proteica (es. 2 scatolette da 80g di tonno al naturale ben sgocciolate, macinata magra, legumi in scatola ben sciacquati)",
+              "120g riso basmati (cotto al cuociriso ~280g) o pasta al dente (cotta ~240g) o altro cereale (miglio, grano saraceno, quinoa, amaranto, sorgo, teff, cous cous) condito con verdure di stagione in abbondanza + circa 100g fonte proteica (es. 2 scatolette da 80g di tonno al naturale ben sgocciolate, macinata magra, legumi in scatola ben sciacquati)",
             ],
           },
           {
@@ -346,7 +346,7 @@ export const days: DayPlan[] = [
           {
             oil: "3 cucchiaini olio EVO a crudo",
             items: [
-              "120g pasta al dente (cotta ~240g) o riso basmati (cotto ~300g) o altro cereale (farro, orzo, miglio, grano saraceno, quinoa, amaranto, sorgo, teff, cous cous) condito con verdure di stagione in abbondanza + circa 100g fonte proteica (es. 2 scatolette da 80g di tonno al naturale ben sgocciolate, affettato magro, salmone affumicato)",
+              "120g pasta al dente (cotta ~240g) o riso basmati (cotto al cuociriso ~280g) o altro cereale (farro, orzo, miglio, grano saraceno, quinoa, amaranto, sorgo, teff, cous cous) condito con verdure di stagione in abbondanza + circa 100g fonte proteica (es. 2 scatolette da 80g di tonno al naturale ben sgocciolate, affettato magro, salmone affumicato)",
             ],
           },
           {
@@ -410,7 +410,7 @@ export const days: DayPlan[] = [
           {
             oil: "3 cucchiaini olio EVO a crudo",
             items: [
-              "120g pasta al dente (cotta ~240g) o riso basmati (cotto ~300g) o altro cereale (orzo, miglio, grano saraceno, quinoa, amaranto, sorgo, teff, cous cous) condito con verdure di stagione in abbondanza + circa 100g fonte proteica (es. 2 scatolette da 80g di tonno al naturale ben sgocciolate, affettato magro, salmone affumicato)",
+              "120g pasta al dente (cotta ~240g) o riso basmati (cotto al cuociriso ~280g) o altro cereale (orzo, miglio, grano saraceno, quinoa, amaranto, sorgo, teff, cous cous) condito con verdure di stagione in abbondanza + circa 100g fonte proteica (es. 2 scatolette da 80g di tonno al naturale ben sgocciolate, affettato magro, salmone affumicato)",
             ],
           },
           {
@@ -473,7 +473,7 @@ export const days: DayPlan[] = [
           {
             oil: "3 cucchiaini olio EVO a crudo",
             items: [
-              "120g riso basmati (cotto ~300g) o pasta al dente (cotta ~240g) o altro cereale (miglio, grano saraceno, quinoa, amaranto, sorgo, teff, cous cous) condito con verdure di stagione in abbondanza + circa 100g fonte proteica (es. 2 scatolette da 80g di tonno al naturale ben sgocciolate, macinata magra, legumi in scatola ben sciacquati)",
+              "120g riso basmati (cotto al cuociriso ~280g) o pasta al dente (cotta ~240g) o altro cereale (miglio, grano saraceno, quinoa, amaranto, sorgo, teff, cous cous) condito con verdure di stagione in abbondanza + circa 100g fonte proteica (es. 2 scatolette da 80g di tonno al naturale ben sgocciolate, macinata magra, legumi in scatola ben sciacquati)",
             ],
           },
           {

--- a/src/data/meal-plan.ts
+++ b/src/data/meal-plan.ts
@@ -151,7 +151,7 @@ export const days: DayPlan[] = [
           {
             oil: "3 cucchiaini olio EVO a crudo",
             items: [
-              "120g riso basmati o pasta al dente o altro cereale (miglio, grano saraceno, quinoa, amaranto, sorgo, teff, cous cous) condito con verdure di stagione in abbondanza + circa 100g fonte proteica (es. 2 scatolette da 80g di tonno al naturale ben sgocciolate, macinata magra, legumi in scatola ben sciacquati)",
+              "120g riso basmati (cotto ~300g) o pasta al dente (cotta ~240g) o altro cereale (miglio, grano saraceno, quinoa, amaranto, sorgo, teff, cous cous) condito con verdure di stagione in abbondanza + circa 100g fonte proteica (es. 2 scatolette da 80g di tonno al naturale ben sgocciolate, macinata magra, legumi in scatola ben sciacquati)",
             ],
           },
           {
@@ -346,7 +346,7 @@ export const days: DayPlan[] = [
           {
             oil: "3 cucchiaini olio EVO a crudo",
             items: [
-              "120g pasta al dente o riso basmati o altro cereale (farro, orzo, miglio, grano saraceno, quinoa, amaranto, sorgo, teff, cous cous) condito con verdure di stagione in abbondanza + circa 100g fonte proteica (es. 2 scatolette da 80g di tonno al naturale ben sgocciolate, affettato magro, salmone affumicato)",
+              "120g pasta al dente (cotta ~240g) o riso basmati (cotto ~300g) o altro cereale (farro, orzo, miglio, grano saraceno, quinoa, amaranto, sorgo, teff, cous cous) condito con verdure di stagione in abbondanza + circa 100g fonte proteica (es. 2 scatolette da 80g di tonno al naturale ben sgocciolate, affettato magro, salmone affumicato)",
             ],
           },
           {
@@ -410,7 +410,7 @@ export const days: DayPlan[] = [
           {
             oil: "3 cucchiaini olio EVO a crudo",
             items: [
-              "120g pasta al dente o riso basmati o altro cereale (orzo, miglio, grano saraceno, quinoa, amaranto, sorgo, teff, cous cous) condito con verdure di stagione in abbondanza + circa 100g fonte proteica (es. 2 scatolette da 80g di tonno al naturale ben sgocciolate, affettato magro, salmone affumicato)",
+              "120g pasta al dente (cotta ~240g) o riso basmati (cotto ~300g) o altro cereale (orzo, miglio, grano saraceno, quinoa, amaranto, sorgo, teff, cous cous) condito con verdure di stagione in abbondanza + circa 100g fonte proteica (es. 2 scatolette da 80g di tonno al naturale ben sgocciolate, affettato magro, salmone affumicato)",
             ],
           },
           {
@@ -473,7 +473,7 @@ export const days: DayPlan[] = [
           {
             oil: "3 cucchiaini olio EVO a crudo",
             items: [
-              "120g riso basmati o pasta al dente o altro cereale (miglio, grano saraceno, quinoa, amaranto, sorgo, teff, cous cous) condito con verdure di stagione in abbondanza + circa 100g fonte proteica (es. 2 scatolette da 80g di tonno al naturale ben sgocciolate, macinata magra, legumi in scatola ben sciacquati)",
+              "120g riso basmati (cotto ~300g) o pasta al dente (cotta ~240g) o altro cereale (miglio, grano saraceno, quinoa, amaranto, sorgo, teff, cous cous) condito con verdure di stagione in abbondanza + circa 100g fonte proteica (es. 2 scatolette da 80g di tonno al naturale ben sgocciolate, macinata magra, legumi in scatola ben sciacquati)",
             ],
           },
           {


### PR DESCRIPTION
## Cosa cambia
Sui 4 pasti giornalieri che includono riso o pasta, aggiunto il peso da cotto inline:

- **Pasta al dente**: 120g secca → `(cotta ~240g)`
- **Riso basmati**: 120g secco → `(cotto al cuociriso ~280g)` (al vapore, assorbe meno acqua del bollito)

Esempi di linea finale:
> 120g riso basmati (cotto al cuociriso ~280g) o pasta al dente (cotta ~240g) o altro cereale…

## Test
- [x] `astro check`: 0 errori

https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C)_