### PR TITLE
feat(comments): auto-approve email già approvate + filtro keyword anti-spam

### DIFF
--- a/src/lib/comments-api.test.ts
+++ b/src/lib/comments-api.test.ts
@@ -264,6 +264,159 @@ describe("POST /api/comments", () => {
     const res = await POST({ request } as never);
     expect(res.status).toBe(400);
   });
+
+  test("silently drops obvious spam (pharmacy keyword)", async () => {
+    const { POST } = await import("~/pages/api/comments");
+    const { request } = makeRequest({
+      pageId: "post-1",
+      name: "Pharma",
+      email: "pharma@example.com",
+      text: "buy viagra cheap online",
+    });
+    const res = await POST({ request } as never);
+    expect(res.status).toBe(200);
+    const rows = await db.execute("SELECT COUNT(*) as c FROM comments");
+    expect(Number(rows.rows[0].c)).toBe(0);
+    expect(emailMocks.notifyNewComment).not.toHaveBeenCalled();
+  });
+
+  test("silently drops comment with three or more URLs", async () => {
+    const { POST } = await import("~/pages/api/comments");
+    const { request } = makeRequest({
+      pageId: "post-1",
+      name: "Linky",
+      email: "linky@example.com",
+      text: "https://a.com https://b.com https://c.com",
+    });
+    const res = await POST({ request } as never);
+    expect(res.status).toBe(200);
+    const rows = await db.execute("SELECT COUNT(*) as c FROM comments");
+    expect(Number(rows.rows[0].c)).toBe(0);
+  });
+
+  test("auto-approves when email already has an approved comment", async () => {
+    await insertComment({
+      pageId: "another-post",
+      name: "Ale",
+      email: "ale@example.com",
+      text: "first comment, approved manually",
+      approved: 1,
+    });
+    const { POST } = await import("~/pages/api/comments");
+    const { request } = makeRequest({
+      pageId: "post-1",
+      name: "Ale",
+      email: "ale@example.com",
+      text: "second comment, should be auto-approved",
+    });
+    const res = await POST({ request } as never);
+    expect(res.status).toBe(201);
+    const rows = await db.execute(
+      "SELECT approved, notified_approved FROM comments WHERE page_id = 'post-1'",
+    );
+    expect(rows.rows.length).toBe(1);
+    expect(rows.rows[0].approved).toBe(1);
+    expect(rows.rows[0].notified_approved).toBe(1);
+    expect(emailMocks.notifyNewComment).not.toHaveBeenCalled();
+  });
+
+  test("email match is case-insensitive", async () => {
+    await insertComment({
+      pageId: "another-post",
+      name: "Ale",
+      email: "Ale@Example.com",
+      text: "first",
+      approved: 1,
+    });
+    const { POST } = await import("~/pages/api/comments");
+    const { request } = makeRequest({
+      pageId: "post-1",
+      name: "Ale",
+      email: "ALE@example.COM",
+      text: "second",
+    });
+    const res = await POST({ request } as never);
+    expect(res.status).toBe(201);
+    const rows = await db.execute(
+      "SELECT approved FROM comments WHERE page_id = 'post-1'",
+    );
+    expect(rows.rows[0].approved).toBe(1);
+  });
+
+  test("first-time email stays pending and triggers admin notification", async () => {
+    const { POST } = await import("~/pages/api/comments");
+    const { request } = makeRequest({
+      pageId: "post-1",
+      name: "Brand",
+      email: "brand-new@example.com",
+      text: "ciao",
+    });
+    const res = await POST({ request } as never);
+    expect(res.status).toBe(201);
+    const rows = await db.execute(
+      "SELECT approved FROM comments WHERE page_id = 'post-1'",
+    );
+    expect(rows.rows[0].approved).toBe(0);
+    expect(emailMocks.notifyNewComment).toHaveBeenCalledOnce();
+  });
+
+  test("auto-approved reply notifies parent author", async () => {
+    await insertComment({
+      pageId: "post-1",
+      name: "Ale",
+      email: "ale@example.com",
+      text: "first by ale",
+      approved: 1,
+    });
+    const parentId = await insertComment({
+      pageId: "post-1",
+      name: "Alice",
+      email: "alice@example.com",
+      text: "Original",
+      approved: 1,
+    });
+    const { POST } = await import("~/pages/api/comments");
+    const { request } = makeRequest({
+      pageId: "post-1",
+      name: "Ale",
+      email: "ale@example.com",
+      text: "reply",
+      parentId,
+    });
+    const res = await POST({ request } as never);
+    expect(res.status).toBe(201);
+    expect(emailMocks.notifyReplyToYourComment).toHaveBeenCalledOnce();
+    const call = emailMocks.notifyReplyToYourComment.mock.calls[0][0];
+    expect(call.parentEmail).toBe("alice@example.com");
+    expect(emailMocks.notifyNewComment).not.toHaveBeenCalled();
+  });
+
+  test("auto-approved reply to own comment does not self-notify", async () => {
+    await insertComment({
+      pageId: "post-1",
+      name: "Ale",
+      email: "ale@example.com",
+      text: "first by ale",
+      approved: 1,
+    });
+    const parentId = await insertComment({
+      pageId: "post-1",
+      name: "Ale",
+      email: "ale@example.com",
+      text: "ale parent",
+      approved: 1,
+    });
+    const { POST } = await import("~/pages/api/comments");
+    const { request } = makeRequest({
+      pageId: "post-1",
+      name: "Ale",
+      email: "ale@example.com",
+      text: "self reply",
+      parentId,
+    });
+    await POST({ request } as never);
+    expect(emailMocks.notifyReplyToYourComment).not.toHaveBeenCalled();
+  });
 });
 
 describe("POST /api/comments — author auto-login", () => {

--- a/src/lib/spam-filter.test.ts
+++ b/src/lib/spam-filter.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect } from "vitest";
+import { isSpam } from "~/lib/spam-filter";
+
+describe("isSpam", () => {
+  test("clean legitimate comment passes", () => {
+    expect(isSpam("Bel post, complimenti!", "Mario")).toBe(false);
+  });
+
+  test("comment with one URL passes", () => {
+    expect(
+      isSpam("Trovi anche un'analisi qui https://example.com/x", "Anna"),
+    ).toBe(false);
+  });
+
+  test("comment with two URLs passes", () => {
+    expect(
+      isSpam(
+        "Approfondimenti: https://a.com/x e https://b.org/y",
+        "Anna",
+      ),
+    ).toBe(false);
+  });
+
+  test("comment with three URLs is spam", () => {
+    expect(
+      isSpam("https://a.com https://b.com https://c.com extra", "Bot"),
+    ).toBe(true);
+  });
+
+  test("viagra keyword flagged", () => {
+    expect(isSpam("buy viagra cheap online", "Pharma")).toBe(true);
+  });
+
+  test("casino keyword flagged", () => {
+    expect(isSpam("Try the best online casino games", "Player")).toBe(true);
+  });
+
+  test("crypto giveaway flagged", () => {
+    expect(isSpam("Free crypto giveaway, claim now", "Elon")).toBe(true);
+  });
+
+  test("SEO service spam flagged", () => {
+    expect(
+      isSpam("Cheap backlinks SEO service available", "Marketing"),
+    ).toBe(true);
+  });
+
+  test("name contains spam keyword still flagged", () => {
+    expect(isSpam("ciao!", "viagra-online")).toBe(true);
+  });
+
+  test(".ru TLD link flagged", () => {
+    expect(isSpam("Look at https://shady.ru/path", "Spammer")).toBe(true);
+  });
+
+  test(".xyz TLD link flagged", () => {
+    expect(isSpam("https://lol.xyz/", "Spammer")).toBe(true);
+  });
+
+  test("normal .com is not flagged", () => {
+    expect(isSpam("Vedi https://example.com", "Anna")).toBe(false);
+  });
+
+  test("Italian comment with no URLs passes", () => {
+    expect(
+      isSpam(
+        "Ho letto tutto d'un fiato. Pezzo che colpisce nel segno.",
+        "Alessandra",
+      ),
+    ).toBe(false);
+  });
+
+  test("empty inputs return false", () => {
+    expect(isSpam("", "")).toBe(false);
+  });
+});

--- a/src/lib/spam-filter.ts
+++ b/src/lib/spam-filter.ts
@@ -1,0 +1,39 @@
+const SPAM_PATTERNS: RegExp[] = [
+  /\bviagra\b/i,
+  /\bcialis\b/i,
+  /\bxanax\b/i,
+  /\btramadol\b/i,
+  /\bcasino\b/i,
+  /\bgambling\b/i,
+  /\bbet365\b/i,
+  /\bpoker(?:stars)?\b/i,
+  /\bbinary\s+option/i,
+  /\bcrypto.{0,20}giveaway/i,
+  /\bonline\s+pharmacy\b/i,
+  /\bpharmac(?:y|ies)\s+online\b/i,
+  /\bcheap\s+(?:meds|pills|drugs)\b/i,
+  /\bbuy\s+(?:cheap|now)\b.*\b(?:online|here)\b/i,
+  /\bsex\s+(?:cam|chat|dating)\b/i,
+  /\bescort(?:s|\s+service)\b/i,
+  /\bSEO\s+services?\b/i,
+  /\bback\s*links?\s+(?:cheap|seo|service)/i,
+];
+
+const SUSPICIOUS_TLD = /\bhttps?:\/\/[^\s/]+\.(ru|tk|ml|ga|cf|gq|xyz|top|click|loan|work|country|stream|download)(?:[/:?#]|\b)/i;
+
+const MAX_URLS = 2;
+
+function countUrls(text: string): number {
+  const matches = text.match(/https?:\/\/\S+/gi);
+  return matches?.length ?? 0;
+}
+
+export function isSpam(text: string, name: string): boolean {
+  const haystack = `${name}\n${text}`;
+  for (const re of SPAM_PATTERNS) {
+    if (re.test(haystack)) return true;
+  }
+  if (SUSPICIOUS_TLD.test(text)) return true;
+  if (countUrls(text) > MAX_URLS) return true;
+  return false;
+}

--- a/src/pages/api/comments.ts
+++ b/src/pages/api/comments.ts
@@ -5,6 +5,7 @@ import { generateStableVisitorHash } from "~/lib/analytics";
 import { verifyBearerToken } from "~/lib/auth";
 import { env } from "~/lib/env";
 import { AUTHOR_NAME, AUTHOR_EMAIL } from "~/lib/author";
+import { isSpam } from "~/lib/spam-filter";
 import {
   type Result,
   ok,
@@ -166,6 +167,14 @@ export const POST: APIRoute = async ({ request }) => {
   return handlePublicPost(body);
 };
 
+async function hasApprovedCommentForEmail(email: string): Promise<boolean> {
+  const res = await getDb().execute({
+    sql: "SELECT 1 FROM comments WHERE LOWER(email) = LOWER(?) AND approved = 1 LIMIT 1",
+    args: [email],
+  });
+  return res.rows.length > 0;
+}
+
 async function handlePublicPost(body: unknown): Promise<Response> {
   const parsed = parseCommentInput(body);
   if (!parsed.ok) return jsonErr(parsed.error, 400);
@@ -173,25 +182,59 @@ async function handlePublicPost(body: unknown): Promise<Response> {
 
   const { pageId, name, email, text, parentId, lang } = parsed.value;
 
-  let parentName: string | null = null;
+  if (isSpam(text, name)) return jsonOk({ ok: true });
+
+  let parent: ParentRow | null = null;
   if (parentId !== null) {
-    const parent = await loadParent(parentId);
+    parent = await loadParent(parentId);
     if (parent === null) return jsonErr("Parent not found", 400);
     if (parent.page_id !== pageId)
       return jsonErr("Parent belongs to a different page", 400);
     if (parent.approved !== 1)
       return jsonErr("Cannot reply to a pending comment", 400);
-    parentName = parent.name;
   }
 
+  const autoApprove = await hasApprovedCommentForEmail(email);
+
   await getDb().execute({
-    sql: "INSERT INTO comments (page_id, name, email, text, parent_id, lang) VALUES (?, ?, ?, ?, ?, ?)",
-    args: [pageId, name, email, text, parentId, lang],
+    sql: `INSERT INTO comments (page_id, name, email, text, parent_id, lang, approved, notified_approved)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      pageId,
+      name,
+      email,
+      text,
+      parentId,
+      lang,
+      autoApprove ? 1 : 0,
+      autoApprove ? 1 : 0,
+    ],
   });
 
-  notifyNewComment({ pageId, name, email, text, parentId, parentName, lang });
+  if (autoApprove) {
+    if (parent !== null && parent.email.toLowerCase() !== email.toLowerCase()) {
+      notifyReplyToYourComment({
+        pageId,
+        parentName: parent.name,
+        parentEmail: parent.email,
+        replyName: name,
+        replyText: text,
+        lang,
+      });
+    }
+  } else {
+    notifyNewComment({
+      pageId,
+      name,
+      email,
+      text,
+      parentId,
+      parentName: parent?.name ?? null,
+      lang,
+    });
+  }
 
-  return jsonOk({ ok: true }, 201);
+  return jsonOk({ ok: true, approved: autoApprove }, 201);
 }
 
 async function handleAuthorPost(body: unknown): Promise<Response> {


### PR DESCRIPTION
## Cosa cambia
Due interventi per ridurre la frizione sul flusso commenti pubblico:

### 1. Auto-approve per email già approvate
Quando arriva un commento da un'email che ha già almeno un commento approvato in tabella, il nuovo commento entra direttamente con `approved=1` e `notified_approved=1`. Niente coda di moderazione, niente mail "in attesa" per Valerio. Match email case-insensitive (`LOWER(email) = LOWER(?)`).

Le risposte ad altri commenter triggerano comunque la notifica al parent author (`notifyReplyToYourComment`).

### 2. Filtro spam a keyword
Nuovo modulo `src/lib/spam-filter.ts` con pattern conservativi: parole farmacia/casinò/SEO, 3+ URL in un commento, TLD sospetti (.ru/.xyz/.tk/.ml/.ga/.cf/.gq/.top/.click/.loan/etc.). Match → comportamento honeypot: 200 OK silente, niente INSERT, niente email.

Prima-volta dalla stessa email resta pending e triggera `notifyNewComment` esattamente come prima.

## Test
- ✅ 14 unit test `spam-filter.test.ts` (positive/negative)
- ✅ 6 nuovi integration test `comments-api.test.ts`:
  - silently drops pharmacy spam
  - silently drops 3+ URLs
  - auto-approves on email match
  - email match case-insensitive
  - first-time email stays pending
  - auto-approved reply notifies parent (non-self)
- ✅ tutti i 332 test pre-esistenti continuano a passare
- ✅ `astro check`: 0 errori

https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C)_