### PR TITLE
feat(visti): recensioni Letterboxd, claps e like

### DIFF
--- a/src/lib/post-stats.ts
+++ b/src/lib/post-stats.ts
@@ -48,3 +48,28 @@ export async function fetchPostStats(): Promise<PostStats> {
     return { claps: {}, comments: {} };
   }
 }
+
+/**
+ * Clap totals for film reviews, keyed by film slug (the `review:` prefix stripped).
+ * Used by the home page "ultima recensione" widget. Empty map if DB is unreachable.
+ */
+export async function fetchReviewClaps(): Promise<Record<string, number>> {
+  try {
+    const db = getDb();
+    const res = await db.execute(
+      `SELECT post_id, SUM(count) AS total
+       FROM post_claps
+       WHERE post_id LIKE 'review:%'
+       GROUP BY post_id`,
+    );
+    const claps: Record<string, number> = {};
+    for (const row of res.rows) {
+      const slug = String(row.post_id ?? "").replace(/^review:/, "");
+      if (slug) claps[slug] = Number(row.total ?? 0);
+    }
+    return claps;
+  } catch (err) {
+    console.error("[post-stats] review claps DB unreachable:", err);
+    return {};
+  }
+}

--- a/src/pages/FoglioHome.css
+++ b/src/pages/FoglioHome.css
@@ -118,6 +118,126 @@
   margin-top: 1rem;
 }
 
+/* ── Latest film review widget ── */
+.fh-review {
+  background: var(--foglio-paper);
+  border-top: 1px solid var(--foglio-rule);
+  border-bottom: 1px solid var(--foglio-rule);
+}
+.fh-review-inner {
+  max-width: var(--foglio-maxw);
+  margin: 0 auto;
+  padding: 4rem 3rem;
+}
+.fh-review-eyebrow {
+  font-family: var(--foglio-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--foglio-accent);
+  margin: 0 0 1.8rem;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+.fh-review-eyebrow::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--foglio-rule);
+}
+.fh-review-grid {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  gap: 2.5rem;
+  align-items: start;
+}
+.fh-review-poster {
+  display: block;
+  width: 130px;
+  aspect-ratio: 2 / 3;
+  background-size: cover;
+  background-position: center;
+  background-color: var(--foglio-paper-2);
+  border: 1px solid var(--foglio-rule);
+  border-radius: var(--foglio-radius-md);
+  box-shadow: var(--foglio-shadow);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+.fh-review-poster:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--foglio-shadow-strong);
+}
+.fh-review-body {
+  max-width: 40em;
+}
+.fh-review-filmtitle {
+  font-family: var(--foglio-serif);
+  font-weight: 500;
+  font-size: 1.9rem;
+  line-height: 1.1;
+  margin: 0 0 0.3rem;
+}
+.fh-review-dir {
+  font-family: var(--foglio-serif);
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--foglio-ink-soft);
+  margin: 0 0 0.5rem;
+}
+.fh-review-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1rem;
+  font-family: var(--foglio-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--foglio-ink-mute);
+  margin-bottom: 1.4rem;
+}
+.fh-review-meta .rating {
+  color: var(--foglio-accent);
+}
+.fh-review-quote {
+  font-family: var(--foglio-serif);
+  font-size: 1.3rem;
+  line-height: 1.55;
+  color: var(--foglio-ink);
+  margin: 0 0 1.5rem;
+  position: relative;
+  padding-top: 1.2rem;
+}
+.fh-review-quote::before {
+  content: "\201C";
+  font-size: 3.4rem;
+  line-height: 1;
+  color: var(--foglio-accent);
+  opacity: 0.35;
+  position: absolute;
+  left: -0.2rem;
+  top: -0.5rem;
+  z-index: 0;
+  font-family: var(--foglio-serif);
+  pointer-events: none;
+}
+.fh-review-quote > * { position: relative; z-index: 1; }
+.fh-review-actions {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+.fh-review-claps {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--foglio-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  color: var(--foglio-accent);
+}
+
 /* ── Section head (shared) ── */
 .fh-section-head {
   display: flex;
@@ -488,6 +608,24 @@
   color: var(--foglio-accent);
 }
 
+.fh-lib-review-dot {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--foglio-accent);
+  margin-left: 0.4rem;
+  vertical-align: middle;
+  opacity: 0.75;
+}
+
+.fh-lib-like {
+  color: var(--foglio-accent);
+  font-size: 0.8rem;
+  margin-left: 0.4rem;
+  vertical-align: middle;
+}
+
 .fh-lib-director {
   display: block;
   font-family: var(--foglio-serif);
@@ -659,6 +797,27 @@
   .fh-lib-detail {
     grid-column: 2;
     font-size: 0.62rem;
+  }
+
+  .fh-review-inner {
+    padding: 2.5rem 1.4rem;
+  }
+
+  .fh-review-grid {
+    grid-template-columns: 88px 1fr;
+    gap: 1.4rem;
+  }
+
+  .fh-review-poster {
+    width: 88px;
+  }
+
+  .fh-review-filmtitle {
+    font-size: 1.5rem;
+  }
+
+  .fh-review-quote {
+    font-size: 1.1rem;
   }
 
   .fh-about-strip {

--- a/src/pages/Visti.css
+++ b/src/pages/Visti.css
@@ -166,6 +166,12 @@
   color: var(--foglio-ink-mute);
 }
 .vw-my-rating { color: var(--foglio-accent); }
+.vw-like {
+  font-size: 0.85rem;
+  line-height: 1;
+  color: var(--foglio-ink-mute);
+}
+.vw-like.is-liked { color: var(--foglio-accent); }
 
 .vw-side {
   text-align: right;
@@ -191,6 +197,113 @@
   color: var(--foglio-ink-soft);
 }
 
+/* ── Inline review (Letterboxd review prose) ───────── */
+.vw-review {
+  margin: 0.2rem 0 0.7rem;
+}
+.vw-review-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0.3rem 0;
+  font-family: var(--foglio-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--foglio-accent);
+  list-style: none;
+}
+.vw-review-toggle::-webkit-details-marker { display: none; }
+.vw-review-toggle:hover { color: var(--foglio-accent-soft); }
+.vw-review-chevron {
+  font-size: 0.6rem;
+  transition: transform 0.2s ease;
+}
+.vw-review[open] .vw-review-chevron,
+.vw-review-toggle.is-open .vw-review-chevron { transform: rotate(90deg); }
+
+.vw-review-body {
+  margin: 0.9rem 0 0.4rem;
+  padding-left: 1rem;
+  border-left: 2px solid var(--foglio-accent);
+  max-width: var(--foglio-maxw-prose);
+}
+.vw-review-text {
+  font-family: var(--foglio-serif);
+  font-size: var(--foglio-fs-sm);
+  line-height: 1.68;
+  color: var(--foglio-ink-soft);
+}
+.vw-review-text p { margin: 0 0 0.7em; }
+.vw-review-text p:last-child { margin-bottom: 0; }
+
+.vw-review-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid var(--foglio-rule);
+}
+
+/* Claps inside the review block — Foglio-tokened variant of PostClaps */
+.PostClaps--inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+.PostClaps--inline .PostClaps-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: none;
+  border: 1px solid var(--foglio-rule-strong);
+  border-radius: 999px;
+  padding: 0.4rem 0.95rem;
+  cursor: pointer;
+  color: var(--foglio-ink);
+  font-family: var(--foglio-mono);
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.PostClaps--inline .PostClaps-button:hover:not(.is-capped) {
+  border-color: var(--foglio-accent);
+  color: var(--foglio-accent);
+}
+.PostClaps--inline .PostClaps-button.is-active {
+  border-color: var(--foglio-accent);
+  color: var(--foglio-accent);
+  background: rgba(168, 69, 26, 0.06);
+}
+.PostClaps--inline .PostClaps-button.is-capped { cursor: not-allowed; opacity: 0.6; }
+.PostClaps--inline .PostClaps-icon { width: 1.25rem; height: 1.25rem; display: inline-flex; }
+.PostClaps--inline .PostClaps-icon svg { display: block; width: 100%; height: 100%; }
+.PostClaps--inline .PostClaps-icon--solid { display: none; }
+.PostClaps--inline .PostClaps-button.is-active .PostClaps-icon:not(.PostClaps-icon--solid) { display: none; }
+.PostClaps--inline .PostClaps-button.is-active .PostClaps-icon--solid { display: inline-flex; }
+.PostClaps--inline .PostClaps-icon.is-pulsing { animation: vw-clap-pulse 0.4s ease-out; }
+@keyframes vw-clap-pulse {
+  0% { transform: scale(1); }
+  40% { transform: scale(1.4) rotate(-8deg); }
+  70% { transform: scale(0.95) rotate(4deg); }
+  100% { transform: scale(1) rotate(0); }
+}
+.PostClaps--inline .PostClaps-total {
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+.PostClaps--inline .PostClaps-yours {
+  font-family: var(--foglio-mono);
+  font-size: 0.64rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--foglio-ink-mute);
+  margin: 0;
+}
+
 @media (max-width: 767px) {
   .vw-head { padding: 2.5rem 1.4rem 1.5rem; }
   .vw-main { padding: 2rem 1.4rem 3rem; }
@@ -207,4 +320,6 @@
   }
   .vw-money { justify-content: flex-start; }
   .vw-overview { -webkit-line-clamp: 3; }
+  .vw-review-body { padding-left: 0.75rem; }
+  .vw-review-actions { flex-wrap: wrap; gap: 0.8rem 1rem; }
 }

--- a/src/pages/api/letterboxd.ts
+++ b/src/pages/api/letterboxd.ts
@@ -1,5 +1,10 @@
 import type { APIRoute } from "astro";
-import { getLetterboxdRss, parseXmlContent } from "~/services/letterboxd";
+import {
+  getLetterboxdRss,
+  parseXmlContent,
+  letterboxdFilmSlug,
+  extractReviewHtml,
+} from "~/services/letterboxd";
 import { getMovieById, extractDirectors } from "~/services/tmdb";
 
 export const prerender = false;
@@ -16,8 +21,10 @@ export const GET: APIRoute = async () => {
       items.map(async (it: any) => {
         try {
           const movie: any = await getMovieById(it["tmdb:movieId"][0]);
+          const link = it.link?.[0] ?? "";
           return {
             title: it["letterboxd:filmTitle"]?.[0] ?? movie.title ?? "",
+            slug: letterboxdFilmSlug(link),
             posterPath: movie.poster_path ?? null,
             budget: typeof movie.budget === "number" ? movie.budget : null,
             revenue: typeof movie.revenue === "number" ? movie.revenue : null,
@@ -27,8 +34,10 @@ export const GET: APIRoute = async () => {
             voteAverage: typeof movie.vote_average === "number" ? movie.vote_average : null,
             runtime: typeof movie.runtime === "number" ? movie.runtime : null,
             rating: it["letterboxd:memberRating"]?.[0] ?? null,
+            liked: it["letterboxd:memberLike"]?.[0] === "Yes",
             watchedDate: it["letterboxd:watchedDate"]?.[0] ?? null,
-            link: it.link?.[0] ?? "",
+            review: extractReviewHtml(it.description?.[0]),
+            link,
           };
         } catch {
           return null;

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -4,7 +4,7 @@ import StructuredData from "~/components/StructuredData.astro";
 import FoglioHeader from "~/components/FoglioHeader.astro";
 import FoglioFooter from "~/components/FoglioFooter.astro";
 import { SITE_TITLE, SITE_DESCRIPTION } from "~/consts";
-import { getLetterboxdRss, parseXmlContent } from "~/services/letterboxd";
+import { getLetterboxdRss, parseXmlContent, extractReviewHtml } from "~/services/letterboxd";
 import { getMovieById, extractDirectors } from "~/services/tmdb";
 import { formatMoneyCompact } from "~/lib/format-money";
 import { getTopPosts } from "~/lib/top-posts";
@@ -24,7 +24,12 @@ const lastWatchedMovies = async () => {
     .map(async (item: any) => {
       try {
         const movie = await getMovieById(item["tmdb:movieId"][0]);
-        return { ...movie, ...item, directors: extractDirectors(movie) };
+        return {
+          ...movie,
+          ...item,
+          directors: extractDirectors(movie),
+          review: extractReviewHtml(item.description?.[0]),
+        };
       } catch (error) {
         console.error(
           `Failed to fetch movie with ID ${item["tmdb:movieId"][0]}`,
@@ -242,6 +247,8 @@ function formatDate(dateStr: string | Date): string {
                   ></div>
                   <div class="fh-lib-title">
                     <em>{movie["letterboxd:filmTitle"]?.[0]}</em>
+                    {movie["letterboxd:memberLike"]?.[0] === "Yes" && <span class="fh-lib-like" title="I liked this">♥</span>}
+                    {movie.review && <span class="fh-lib-review-dot" title="Has a review"></span>}
                     {(() => {
                       const b = formatMoneyCompact(movie.budget);
                       const r = formatMoneyCompact(movie.revenue);
@@ -322,7 +329,7 @@ function formatDate(dateStr: string | Date): string {
       if (block) {
         fetchWatched()
           .then((movies) => {
-            if (movies.length > 0) renderCompact(block, movies, { locale: "en-GB", byLabel: "by" });
+            if (movies.length > 0) renderCompact(block, movies, { locale: "en-GB", byLabel: "by", likedLabel: "I liked this" });
           })
           .catch(() => {});
       }

--- a/src/pages/en/watched.astro
+++ b/src/pages/en/watched.astro
@@ -3,15 +3,22 @@ import BaseHead from "~/components/BaseHead.astro";
 import FoglioHeader from "~/components/FoglioHeader.astro";
 import FoglioFooter from "~/components/FoglioFooter.astro";
 import { SITE_TITLE } from "~/consts";
-import { getLetterboxdRss, parseXmlContent } from "~/services/letterboxd";
+import {
+  getLetterboxdRss,
+  parseXmlContent,
+  letterboxdFilmSlug,
+  extractReviewHtml,
+} from "~/services/letterboxd";
 import { getMovieById, extractDirectors } from "~/services/tmdb";
 import { formatMoneyCompact } from "~/lib/format-money";
 import { letterboxdDirectorUrl } from "~/lib/letterboxd-slug";
+import { Icon } from "astro-icon/components";
 import "~/styles/foglio.css";
 import "../Visti.css";
 
 interface WatchedMovie {
   title?: string;
+  slug?: string | null;
   watchedDate?: string;
   rating?: string;
   poster_path?: string;
@@ -22,6 +29,8 @@ interface WatchedMovie {
   vote_average?: number;
   runtime?: number;
   directors?: string[];
+  review?: string | null;
+  liked?: boolean;
 }
 
 const fetchAllWatched = async (): Promise<WatchedMovie[]> => {
@@ -39,8 +48,11 @@ const fetchAllWatched = async (): Promise<WatchedMovie[]> => {
             ...(movie as any),
             directors: extractDirectors(movie),
             title: it["letterboxd:filmTitle"]?.[0],
+            slug: letterboxdFilmSlug(it.link?.[0]),
             watchedDate: it["letterboxd:watchedDate"]?.[0],
             rating: it["letterboxd:memberRating"]?.[0],
+            liked: it["letterboxd:memberLike"]?.[0] === "Yes",
+            review: extractReviewHtml(it.description?.[0]),
           } as WatchedMovie;
         } catch {
           return null;
@@ -173,7 +185,19 @@ if (myRatings.length > 0) {
                           </>
                         ))}</span></p>
                       )}
-                      {m.overview && <p class="vw-overview">{m.overview}</p>}
+                      {m.review && m.slug ? (
+                        <details class="vw-review" id={`review-${m.slug}`}>
+                          <summary class="vw-review-toggle">
+                            <span class="vw-review-chevron" aria-hidden="true">▸</span>
+                            My review
+                          </summary>
+                          <div class="vw-review-body">
+                            <div class="vw-review-text" set:html={m.review} />
+                          </div>
+                        </details>
+                      ) : (
+                        m.overview && <p class="vw-overview">{m.overview}</p>
+                      )}
                       <div class="vw-meta">
                         {m.release_date && <span>{m.release_date.slice(0, 4)}</span>}
                         {typeof m.runtime === "number" && m.runtime > 0 && (
@@ -183,6 +207,7 @@ if (myRatings.length > 0) {
                           <span>★ {m.vote_average.toFixed(1)}</span>
                         )}
                         {m.rating && <span class="vw-my-rating">my rating: {m.rating}/5</span>}
+                        <span class={`vw-like${m.liked ? " is-liked" : ""}`} title={m.liked ? "I liked this" : "Not a favourite"} aria-label={m.liked ? "I liked this" : "Not a favourite"}>{m.liked ? "♥" : "♡"}</span>
                       </div>
                     </div>
                     <div class="vw-side">
@@ -206,6 +231,11 @@ if (myRatings.length > 0) {
 
     <FoglioFooter lang="en" />
 
+    <template id="vw-clap-icons">
+      <Icon name="ph:hands-clapping" class="PostClaps-icon" size={20} is:inline aria-hidden="true" />
+      <Icon name="ph:hands-clapping-fill" class="PostClaps-icon PostClaps-icon--solid" size={20} is:inline aria-hidden="true" />
+    </template>
+
     <script>
       import { fetchWatched, renderFull } from "~/scripts/watched-movies";
       const main = document.querySelector<HTMLElement>("[data-watched-main]");
@@ -217,6 +247,15 @@ if (myRatings.length > 0) {
                 locale: "en-GB",
                 byLabel: "by",
                 myRatingLabel: (r) => `my rating: ${r}/5`,
+                likedLabel: "I liked this",
+                notLikedLabel: "Not a favourite",
+                review: {
+                  toggle: "My review",
+                  clapCta: "Clap for this review",
+                  clapYoursOne: "You clapped once",
+                  clapYours: "You clapped {n} times",
+                  clapCapped: "You reached the max (50)",
+                },
               });
           })
           .catch(() => {});

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,12 +4,17 @@ import StructuredData from "~/components/StructuredData.astro";
 import FoglioHeader from "~/components/FoglioHeader.astro";
 import FoglioFooter from "~/components/FoglioFooter.astro";
 import { SITE_TITLE, SITE_DESCRIPTION } from "~/consts";
-import { getLetterboxdRss, parseXmlContent } from "~/services/letterboxd";
+import {
+  getLetterboxdRss,
+  parseXmlContent,
+  extractReviewHtml,
+  letterboxdFilmSlug,
+} from "~/services/letterboxd";
 import { getMovieById, extractDirectors } from "~/services/tmdb";
 import { fetchRecentTracks } from "~/services/audioscrobbler";
 import { formatMoneyCompact } from "~/lib/format-money";
 import { getTopPosts } from "~/lib/top-posts";
-import { fetchPostStats } from "~/lib/post-stats";
+import { fetchPostStats, fetchReviewClaps } from "~/lib/post-stats";
 import { getCollection } from "astro:content";
 import { getLangFromId, getSlugFromId } from "~/i18n/utils";
 import "~/styles/foglio.css";
@@ -24,7 +29,13 @@ const lastWatchedMovies = async () => {
     .map(async (item: any) => {
       try {
         const movie = await getMovieById(item["tmdb:movieId"][0]);
-        return { ...movie, ...item, directors: extractDirectors(movie) };
+        return {
+          ...movie,
+          ...item,
+          directors: extractDirectors(movie),
+          slug: letterboxdFilmSlug(item.link?.[0]),
+          review: extractReviewHtml(item.description?.[0]),
+        };
       } catch (error) {
         console.error(
           `Failed to fetch movie with ID ${item["tmdb:movieId"][0]}`,
@@ -82,10 +93,18 @@ const films = allFilmEntries
     slug: getSlugFromId(e.id),
   }));
 
-const [lastWatched, lastSongs] = await Promise.all([
+const [lastWatched, lastSongs, reviewClaps] = await Promise.all([
   lastWatchedMovies().catch(() => []),
   fetchRecentTracks().catch(() => []),
+  fetchReviewClaps().catch(() => ({}) as Record<string, number>),
 ]);
+
+const reviewedMovies = (lastWatched as any[]).filter((m) => m.review && m.slug);
+const latestReview = reviewedMovies[0] ?? null;
+const latestReviewExcerpt = latestReview
+  ? (latestReview.review.match(/<p>([\s\S]*?)<\/p>/i)?.[1] ?? "").trim()
+  : "";
+const latestReviewClaps = latestReview ? (reviewClaps[latestReview.slug] ?? 0) : 0;
 
 function formatDate(dateStr: string | Date): string {
   const d = new Date(dateStr);
@@ -226,6 +245,48 @@ function formatDate(dateStr: string | Date): string {
       )}
     </section>
 
+    <!-- 4b. Latest film review -->
+    {latestReview && (
+      <section class="fh-review">
+        <div class="fh-review-inner">
+          <p class="fh-review-eyebrow">La mia ultima recensione</p>
+          <div class="fh-review-grid">
+            <a class="fh-review-poster" href={`/visti#review-${latestReview.slug}`}
+              style={latestReview.poster_path ? `background-image: url('https://image.tmdb.org/t/p/w342/${latestReview.poster_path}')` : ""}
+              aria-label={latestReview["letterboxd:filmTitle"]?.[0]}
+            ></a>
+            <div class="fh-review-body">
+              <h3 class="fh-review-filmtitle">{latestReview["letterboxd:filmTitle"]?.[0]}</h3>
+              {latestReview.directors?.length > 0 && (
+                <p class="fh-review-dir">di {latestReview.directors.join(", ")}</p>
+              )}
+              <div class="fh-review-meta">
+                {latestReview.release_date && <span>{latestReview.release_date.slice(0, 4)}</span>}
+                {typeof latestReview.runtime === "number" && latestReview.runtime > 0 && (
+                  <span>{latestReview.runtime}′</span>
+                )}
+                {latestReview["letterboxd:watchedDate"]?.[0] && (
+                  <span>visto il {formatDate(latestReview["letterboxd:watchedDate"][0])}</span>
+                )}
+                {latestReview["letterboxd:memberLike"]?.[0] === "Yes" && (
+                  <span class="rating">♥ mi è piaciuto</span>
+                )}
+              </div>
+              {latestReviewExcerpt && (
+                <p class="fh-review-quote" set:html={latestReviewExcerpt} />
+              )}
+              <div class="fh-review-actions">
+                <a href={`/visti#review-${latestReview.slug}`} class="foglio-readmore">Leggi su Visti →</a>
+                {latestReviewClaps > 0 && (
+                  <span class="fh-review-claps">♥ {latestReviewClaps} applausi</span>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    )}
+
     <!-- 5. Library -->
     <section class="fh-library">
       <div class="fh-library-inner">
@@ -241,6 +302,8 @@ function formatDate(dateStr: string | Date): string {
                   ></div>
                   <div class="fh-lib-title">
                     <em>{movie["letterboxd:filmTitle"]?.[0]}</em>
+                    {movie["letterboxd:memberLike"]?.[0] === "Yes" && <span class="fh-lib-like" title="Mi è piaciuto">♥</span>}
+                    {movie.review && <span class="fh-lib-review-dot" title="Ha una recensione"></span>}
                     {(() => {
                       const b = formatMoneyCompact(movie.budget);
                       const r = formatMoneyCompact(movie.revenue);
@@ -321,7 +384,7 @@ function formatDate(dateStr: string | Date): string {
       if (block) {
         fetchWatched()
           .then((movies) => {
-            if (movies.length > 0) renderCompact(block, movies, { locale: "it-IT", byLabel: "di" });
+            if (movies.length > 0) renderCompact(block, movies, { locale: "it-IT", byLabel: "di", likedLabel: "Mi è piaciuto" });
           })
           .catch(() => {});
       }

--- a/src/pages/visti.astro
+++ b/src/pages/visti.astro
@@ -3,15 +3,22 @@ import BaseHead from "~/components/BaseHead.astro";
 import FoglioHeader from "~/components/FoglioHeader.astro";
 import FoglioFooter from "~/components/FoglioFooter.astro";
 import { SITE_TITLE } from "~/consts";
-import { getLetterboxdRss, parseXmlContent } from "~/services/letterboxd";
+import {
+  getLetterboxdRss,
+  parseXmlContent,
+  letterboxdFilmSlug,
+  extractReviewHtml,
+} from "~/services/letterboxd";
 import { getMovieById, extractDirectors } from "~/services/tmdb";
 import { formatMoneyCompact } from "~/lib/format-money";
 import { letterboxdDirectorUrl } from "~/lib/letterboxd-slug";
+import { Icon } from "astro-icon/components";
 import "~/styles/foglio.css";
 import "./Visti.css";
 
 interface WatchedMovie {
   title?: string;
+  slug?: string | null;
   watchedDate?: string;
   rating?: string;
   poster_path?: string;
@@ -22,6 +29,8 @@ interface WatchedMovie {
   vote_average?: number;
   runtime?: number;
   directors?: string[];
+  review?: string | null;
+  liked?: boolean;
 }
 
 const fetchAllWatched = async (): Promise<WatchedMovie[]> => {
@@ -39,8 +48,11 @@ const fetchAllWatched = async (): Promise<WatchedMovie[]> => {
             ...(movie as any),
             directors: extractDirectors(movie),
             title: it["letterboxd:filmTitle"]?.[0],
+            slug: letterboxdFilmSlug(it.link?.[0]),
             watchedDate: it["letterboxd:watchedDate"]?.[0],
             rating: it["letterboxd:memberRating"]?.[0],
+            liked: it["letterboxd:memberLike"]?.[0] === "Yes",
+            review: extractReviewHtml(it.description?.[0]),
           } as WatchedMovie;
         } catch {
           return null;
@@ -173,7 +185,19 @@ if (myRatings.length > 0) {
                           </>
                         ))}</span></p>
                       )}
-                      {m.overview && <p class="vw-overview">{m.overview}</p>}
+                      {m.review && m.slug ? (
+                        <details class="vw-review" id={`review-${m.slug}`}>
+                          <summary class="vw-review-toggle">
+                            <span class="vw-review-chevron" aria-hidden="true">▸</span>
+                            La mia recensione
+                          </summary>
+                          <div class="vw-review-body">
+                            <div class="vw-review-text" set:html={m.review} />
+                          </div>
+                        </details>
+                      ) : (
+                        m.overview && <p class="vw-overview">{m.overview}</p>
+                      )}
                       <div class="vw-meta">
                         {m.release_date && <span>{m.release_date.slice(0, 4)}</span>}
                         {typeof m.runtime === "number" && m.runtime > 0 && (
@@ -183,6 +207,7 @@ if (myRatings.length > 0) {
                           <span>★ {m.vote_average.toFixed(1)}</span>
                         )}
                         {m.rating && <span class="vw-my-rating">il mio: {m.rating}/5</span>}
+                        <span class={`vw-like${m.liked ? " is-liked" : ""}`} title={m.liked ? "Mi è piaciuto" : "Non tra i preferiti"} aria-label={m.liked ? "Mi è piaciuto" : "Non tra i preferiti"}>{m.liked ? "♥" : "♡"}</span>
                       </div>
                     </div>
                     <div class="vw-side">
@@ -206,6 +231,11 @@ if (myRatings.length > 0) {
 
     <FoglioFooter lang="it" />
 
+    <template id="vw-clap-icons">
+      <Icon name="ph:hands-clapping" class="PostClaps-icon" size={20} is:inline aria-hidden="true" />
+      <Icon name="ph:hands-clapping-fill" class="PostClaps-icon PostClaps-icon--solid" size={20} is:inline aria-hidden="true" />
+    </template>
+
     <script>
       import { fetchWatched, renderFull } from "~/scripts/watched-movies";
       const main = document.querySelector<HTMLElement>("[data-watched-main]");
@@ -217,6 +247,15 @@ if (myRatings.length > 0) {
                 locale: "it-IT",
                 byLabel: "di",
                 myRatingLabel: (r) => `il mio: ${r}/5`,
+                likedLabel: "Mi è piaciuto",
+                notLikedLabel: "Non tra i preferiti",
+                review: {
+                  toggle: "La mia recensione",
+                  clapCta: "Applaudi questa recensione",
+                  clapYoursOne: "Hai applaudito 1 volta",
+                  clapYours: "Hai applaudito {n} volte",
+                  clapCapped: "Hai raggiunto il massimo (50)",
+                },
               });
           })
           .catch(() => {});

--- a/src/scripts/watched-movies.ts
+++ b/src/scripts/watched-movies.ts
@@ -3,6 +3,7 @@ import { letterboxdDirectorUrl } from "~/lib/letterboxd-slug";
 
 export interface WatchedMovie {
   title: string;
+  slug: string | null;
   posterPath: string | null;
   budget: number | null;
   revenue: number | null;
@@ -12,19 +13,47 @@ export interface WatchedMovie {
   voteAverage: number | null;
   runtime: number | null;
   rating: string | null;
+  liked: boolean;
   watchedDate: string | null;
+  review: string | null;
   link: string;
 }
 
 export interface CompactOptions {
   locale: string;
   byLabel: string;
+  likedLabel?: string;
+  notLikedLabel?: string;
+}
+
+export interface ReviewLabels {
+  toggle: string;
+  clapCta: string;
+  clapYoursOne: string;
+  clapYours: string;
+  clapCapped: string;
 }
 
 export interface FullOptions {
   locale: string;
   byLabel: string;
   myRatingLabel: (rating: string) => string;
+  likedLabel: string;
+  notLikedLabel: string;
+  review: ReviewLabels;
+}
+
+// Filled heart when liked on Letterboxd, hollow heart otherwise.
+function likeHeart(liked: boolean, likedLabel: string, notLikedLabel: string): HTMLElement {
+  return el(
+    "span",
+    {
+      class: `vw-like${liked ? " is-liked" : ""}`,
+      title: liked ? likedLabel : notLikedLabel,
+      "aria-label": liked ? likedLabel : notLikedLabel,
+    },
+    liked ? "♥" : "♡",
+  );
 }
 
 type Child = Node | string | null | undefined | false;
@@ -66,6 +95,14 @@ function compactItem(m: WatchedMovie, opts: CompactOptions): HTMLElement {
   }
 
   const title = el("div", { class: "fh-lib-title" }, el("em", null, m.title));
+  if (m.liked) {
+    title.append(
+      el("span", { class: "fh-lib-like", title: opts.likedLabel ?? "Mi è piaciuto" }, "♥"),
+    );
+  }
+  if (m.review && m.slug) {
+    title.append(el("span", { class: "fh-lib-review-dot", title: "Ha una recensione" }));
+  }
 
   const b = formatMoneyCompact(m.budget);
   const r = formatMoneyCompact(m.revenue);
@@ -110,6 +147,152 @@ export function renderCompact(
   else block.append(ul);
 }
 
+const CLAP_MAX = 50;
+
+function cloneClapIcons(): DocumentFragment {
+  const tpl = document.getElementById("vw-clap-icons") as HTMLTemplateElement | null;
+  return tpl ? (tpl.content.cloneNode(true) as DocumentFragment) : document.createDocumentFragment();
+}
+
+// Lazy claps: the count is only fetched the first time the review is opened,
+// so a /visti page with many reviewed films makes zero clap requests on load.
+function buildReviewClaps(slug: string, labels: ReviewLabels): HTMLElement {
+  const total = el("span", { class: "PostClaps-total" }, "0");
+  const button = el(
+    "button",
+    { type: "button", class: "PostClaps-button", "aria-label": labels.clapCta },
+    cloneClapIcons(),
+    total,
+  );
+  const yours = el("p", { class: "PostClaps-yours", hidden: "" });
+  const section = el("div", { class: "PostClaps PostClaps--inline" }, button, yours);
+
+  const postId = `review:${slug}`;
+  let mine = 0;
+  let count = 0;
+  let max = CLAP_MAX;
+  let loaded = false;
+  let inflight = 0;
+
+  function render(): void {
+    total.textContent = String(count);
+    button.classList.toggle("is-capped", mine >= max);
+    button.classList.toggle("is-active", mine > 0);
+    button.setAttribute("aria-pressed", mine > 0 ? "true" : "false");
+    if (mine === 0) {
+      yours.hidden = true;
+      yours.textContent = "";
+    } else if (mine >= max) {
+      yours.hidden = false;
+      yours.textContent = labels.clapCapped;
+    } else if (mine === 1) {
+      yours.hidden = false;
+      yours.textContent = labels.clapYoursOne;
+    } else {
+      yours.hidden = false;
+      yours.textContent = labels.clapYours.replace("{n}", String(mine));
+    }
+  }
+
+  function pulse(): void {
+    section.querySelectorAll(".PostClaps-icon").forEach((icon) => {
+      icon.classList.remove("is-pulsing");
+      void (icon as HTMLElement).offsetWidth;
+      icon.classList.add("is-pulsing");
+    });
+  }
+
+  function load(): void {
+    if (loaded) return;
+    loaded = true;
+    fetch(`/api/posts/claps?postId=${encodeURIComponent(postId)}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (typeof data.max === "number") max = data.max;
+        mine = Number(data.mine) || 0;
+        count = Number(data.total) || 0;
+        render();
+      })
+      .catch(() => {});
+  }
+
+  button.addEventListener("click", () => {
+    if (mine >= max) return;
+    mine = Math.min(mine + 1, max);
+    count += 1;
+    render();
+    pulse();
+    inflight += 1;
+    fetch("/api/posts/claps", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ postId }),
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        inflight -= 1;
+        if (inflight === 0) {
+          mine = Number(data.mine) || mine;
+          count = Number(data.total) || count;
+          if (typeof data.max === "number") max = data.max;
+          render();
+        }
+      })
+      .catch(() => {
+        inflight -= 1;
+      });
+  });
+
+  (section as HTMLElement & { loadCounts: () => void }).loadCounts = load;
+  return section;
+}
+
+function buildReviewBlock(m: WatchedMovie, opts: FullOptions): HTMLElement | null {
+  if (!m.review || !m.slug) return null;
+
+  const text = el("div", { class: "vw-review-text" });
+  text.innerHTML = m.review;
+
+  const claps = buildReviewClaps(m.slug, opts.review);
+  const actions = el("div", { class: "vw-review-actions" }, claps);
+  const body = el("div", { class: "vw-review-body", hidden: "" }, text, actions);
+
+  const chevron = el("span", { class: "vw-review-chevron", "aria-hidden": "true" }, "▸");
+  const toggle = el(
+    "button",
+    { type: "button", class: "vw-review-toggle", "aria-expanded": "false" },
+    chevron,
+    opts.review.toggle,
+  );
+
+  let clapsLoaded = false;
+  toggle.addEventListener("click", () => {
+    const open = body.hidden;
+    body.hidden = !open;
+    toggle.setAttribute("aria-expanded", open ? "true" : "false");
+    toggle.classList.toggle("is-open", open);
+    if (open && !clapsLoaded) {
+      clapsLoaded = true;
+      (claps as HTMLElement & { loadCounts?: () => void }).loadCounts?.();
+    }
+  });
+
+  return el("div", { class: "vw-review", id: `review-${m.slug}` }, toggle, body);
+}
+
+// When arriving via /visti#review-<slug> (e.g. from the home widget), open
+// that review and bring it into view once the list has been re-rendered.
+function openReviewFromHash(): void {
+  const hash = window.location.hash;
+  if (!hash.startsWith("#review-")) return;
+  const target = document.getElementById(hash.slice(1));
+  if (!target) return;
+  const toggle = target.querySelector<HTMLButtonElement>(".vw-review-toggle");
+  const body = target.querySelector<HTMLElement>(".vw-review-body");
+  if (toggle && body && body.hidden) toggle.click();
+  target.scrollIntoView({ behavior: "smooth", block: "center" });
+}
+
 function fullRow(m: WatchedMovie, opts: FullOptions): HTMLElement {
   const cover = el("div", { class: "vw-cover" });
   if (m.posterPath) {
@@ -138,7 +321,9 @@ function fullRow(m: WatchedMovie, opts: FullOptions): HTMLElement {
     col.append(el("p", { class: "vw-director" }, `${opts.byLabel} `, span));
   }
 
-  if (m.overview) col.append(el("p", { class: "vw-overview" }, m.overview));
+  const reviewBlock = buildReviewBlock(m, opts);
+  if (reviewBlock) col.append(reviewBlock);
+  else if (m.overview) col.append(el("p", { class: "vw-overview" }, m.overview));
 
   const meta = el("div", { class: "vw-meta" });
   if (m.releaseDate) meta.append(el("span", null, m.releaseDate.slice(0, 4)));
@@ -151,6 +336,7 @@ function fullRow(m: WatchedMovie, opts: FullOptions): HTMLElement {
   if (m.rating) {
     meta.append(el("span", { class: "vw-my-rating" }, opts.myRatingLabel(m.rating)));
   }
+  meta.append(likeHeart(m.liked, opts.likedLabel, opts.notLikedLabel));
   col.append(meta);
 
   const side = el("div", { class: "vw-side" });
@@ -235,4 +421,5 @@ export function renderFull(
 
   main.replaceChildren(...sections);
   updateStats(movies);
+  openReviewFromHash();
 }

--- a/src/services/letterboxd.test.ts
+++ b/src/services/letterboxd.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { extractReviewHtml, letterboxdFilmSlug } from "./letterboxd";
+
+describe("letterboxdFilmSlug", () => {
+  it("extracts the slug from a member film link", () => {
+    expect(letterboxdFilmSlug("https://letterboxd.com/valenar/film/smart-working/")).toBe(
+      "smart-working",
+    );
+  });
+
+  it("handles slugs with year suffixes", () => {
+    expect(letterboxdFilmSlug("https://letterboxd.com/valenar/film/backrooms-2026/")).toBe(
+      "backrooms-2026",
+    );
+  });
+
+  it("works without a trailing slash", () => {
+    expect(letterboxdFilmSlug("https://letterboxd.com/valenar/film/conclave")).toBe("conclave");
+  });
+
+  it("returns null for undefined or non-film links", () => {
+    expect(letterboxdFilmSlug(undefined)).toBeNull();
+    expect(letterboxdFilmSlug("https://letterboxd.com/valenar/")).toBeNull();
+  });
+});
+
+describe("extractReviewHtml", () => {
+  it("returns null when description is missing", () => {
+    expect(extractReviewHtml(undefined)).toBeNull();
+  });
+
+  it("returns null for a poster-only entry (no review prose)", () => {
+    const description = `<p><img src="https://a.ltrbxd.com/poster.jpg"/></p>`;
+    expect(extractReviewHtml(description)).toBeNull();
+  });
+
+  it("strips the poster image and keeps the review paragraphs", () => {
+    const description = `<p><img src="https://a.ltrbxd.com/poster.jpg"/></p> <p>Bella sorpresa.</p>`;
+    expect(extractReviewHtml(description)).toBe("<p>Bella sorpresa.</p>");
+  });
+
+  it("keeps multiple paragraphs in order", () => {
+    const description = `<p><img src="x.jpg"/></p> <p>Primo.</p><p>Secondo.</p>`;
+    expect(extractReviewHtml(description)).toBe("<p>Primo.</p><p>Secondo.</p>");
+  });
+
+  it("removes anchor tags but keeps their text", () => {
+    const description = `<p>Vedi <a href="https://example.com">qui</a> il film.</p>`;
+    expect(extractReviewHtml(description)).toBe("<p>Vedi qui il film.</p>");
+  });
+
+  it("drops empty paragraphs left after stripping the image", () => {
+    const description = `<p> <img src="x.jpg"/> </p><p>Testo vero.</p>`;
+    expect(extractReviewHtml(description)).toBe("<p>Testo vero.</p>");
+  });
+
+  it("returns null for the 'Watched on …' auto-placeholder (no real review)", () => {
+    const description = `<p><img src="x.jpg"/></p> <p>Watched on Friday June 5, 2026.</p>`;
+    expect(extractReviewHtml(description)).toBeNull();
+  });
+
+  it("returns null for the placeholder without trailing period", () => {
+    const description = `<p></p> <p>Watched on Saturday May 30, 2026</p>`;
+    expect(extractReviewHtml(description)).toBeNull();
+  });
+
+  it("keeps a real review even if it mentions a watch date elsewhere", () => {
+    const description = `<p><img src="x.jpg"/></p> <p>Visto venerdì. Bellissimo film.</p>`;
+    expect(extractReviewHtml(description)).toBe("<p>Visto venerdì. Bellissimo film.</p>");
+  });
+});

--- a/src/services/letterboxd.ts
+++ b/src/services/letterboxd.ts
@@ -25,3 +25,35 @@ export const parseXmlContent = (xmlContent: string): Promise<unknown> =>
       }
     });
   });
+
+const FILM_SLUG_RE = /\/film\/([^/]+)\/?$/;
+
+export function letterboxdFilmSlug(link: string | undefined): string | null {
+  if (!link) return null;
+  const match = FILM_SLUG_RE.exec(link.trim());
+  return match ? match[1] : null;
+}
+
+// Letterboxd emits this exact prose as the only paragraph when a film was
+// logged WITHOUT a written review — it is a placeholder, not authored content.
+const WATCHED_PLACEHOLDER_RE = /^Watched on \w+ \w+ \d{1,2}, \d{4}\.?$/i;
+
+// The RSS <description> bundles the poster <img> with the optional review prose.
+// We drop the poster and any links, keep only the paragraph text so the review
+// reads as plain authored prose. Returns null when the entry has no real review
+// (empty, or just the "Watched on …" placeholder Letterboxd auto-generates).
+export function extractReviewHtml(description: string | undefined): string | null {
+  if (!description) return null;
+
+  const withoutImages = description.replace(/<img[^>]*>/gi, "");
+  const paragraphs = [...withoutImages.matchAll(/<p>([\s\S]*?)<\/p>/gi)]
+    .map((m) => m[1].replace(/<\/?a[^>]*>/gi, "").trim())
+    .filter((text) => text.length > 0);
+
+  if (paragraphs.length === 0) return null;
+  if (paragraphs.length === 1 && WATCHED_PLACEHOLDER_RE.test(paragraphs[0])) {
+    return null;
+  }
+
+  return paragraphs.map((text) => `<p>${text}</p>`).join("");
+}


### PR DESCRIPTION
Le piccole recensioni scritte su Letterboxd ora compaiono sul sito.

## Cosa cambia

**`/visti` — recensioni inline + claps**
- Toggle "La mia recensione" che espande inline la prosa scritta su Letterboxd (no overlay, no drawer; identico desktop/mobile).
- Claps lazy-loaded dentro il blocco recensione: riusano `PostClaps` (key `review:<slug>`), la fetch del conteggio parte solo alla prima apertura.
- Il blocco appare **solo se esiste una recensione vera**: `extractReviewHtml` scarta il placeholder `Watched on …` che Letterboxd auto-genera quando logghi un film senza scrivere nulla.

**Home — widget "La mia ultima recensione"**
- Nuovo blocco tra Blog e Library, mostrato solo se c'è almeno una recensione.
- Poster + estratto + link `→ /visti#review-<slug>` che apre e centra la recensione corrispondente.
- Conteggio applausi read-only (`fetchReviewClaps()`).

**Like Letterboxd ovunque**
- `memberLike` fetchato e mostrato come cuore pieno/vuoto (♥/♡) su `/visti`, home compact e widget — al posto del voto numerico (che non uso).

## Tecnico
- Nuovi helper `extractReviewHtml` + `letterboxdFilmSlug` in `services/letterboxd.ts`, con test dedicati (`letterboxd.test.ts`).
- `fetchReviewClaps()` in `post-stats.ts` (claps aggregati per `review:%`).
- Zero modifiche backend: claps riusano l'endpoint esistente con ID `review:<slug>`.
- Speculare su versione EN (`/en/watched`, `/en`).

## Test
- 324/324 verdi (di cui 13 nuovi su `extractReviewHtml`/`letterboxdFilmSlug`, inclusi i casi del placeholder "Watched on …").
- Build verde.

## Note
- I claps partono da 0 (ID nuovo `review:<slug>`).
- Documentazione (`README`, `CLAUDE.md`, `docs/visti-spec.md`) e un ritocco estetico del widget restano da fare in follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)