### PR TITLE
fix(visti): label onesti + CTA a Letterboxd

### DIFF
--- a/src/pages/Visti.css
+++ b/src/pages/Visti.css
@@ -32,8 +32,22 @@
   line-height: 1.55;
   color: var(--foglio-ink-soft);
   max-width: 38em;
+  margin: 0 0 1rem;
+}
+.vw-letterboxd-cta {
+  font-family: var(--foglio-mono);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
   margin: 0 0 2.5rem;
 }
+.vw-letterboxd-cta a {
+  color: var(--foglio-accent);
+  border-bottom: 1px solid currentColor;
+  padding-bottom: 2px;
+  transition: opacity 0.15s;
+}
+.vw-letterboxd-cta a:hover { opacity: 0.7; }
 .vw-stats {
   display: grid;
   grid-template-columns: repeat(4, 1fr);

--- a/src/pages/en/watched.astro
+++ b/src/pages/en/watched.astro
@@ -118,7 +118,7 @@ if (myRatings.length > 0) {
   <head>
     <BaseHead
       title={`Watched · ${SITE_TITLE}`}
-      description="Full list of films I've watched recently, with dates, budget and box office revenue. Data from Letterboxd + TMDB."
+      description="Latest viewings from my Letterboxd feed, with dates, budget and box office. Full diary on Letterboxd."
     />
   </head>
   <body>
@@ -131,10 +131,15 @@ if (myRatings.length > 0) {
         What I've watched recently — Letterboxd feed, metadata from TMDB.
         Budget and box office when available.
       </p>
+      <p class="vw-letterboxd-cta">
+        <a href="https://letterboxd.com/valenar/" target="_blank" rel="noopener noreferrer">
+          Full diary on Letterboxd →
+        </a>
+      </p>
 
       <dl class="vw-stats">
         <div class="vw-stat">
-          <dt>Films</dt>
+          <dt>Latest watched</dt>
           <dd data-stat="total">{totalCount}</dd>
         </div>
         <div class="vw-stat">

--- a/src/pages/visti.astro
+++ b/src/pages/visti.astro
@@ -118,7 +118,7 @@ if (myRatings.length > 0) {
   <head>
     <BaseHead
       title={`Visti · ${SITE_TITLE}`}
-      description="Lista completa dei film visti, con date, budget e incassi al box office. Dati Letterboxd + TMDB."
+      description="Ultime visioni dal feed Letterboxd con date, budget e incassi al box office. Diario completo su Letterboxd."
     />
   </head>
   <body>
@@ -131,10 +131,15 @@ if (myRatings.length > 0) {
         Cosa ho guardato di recente — feed Letterboxd, metadata da TMDB.
         Budget e box office quando disponibili.
       </p>
+      <p class="vw-letterboxd-cta">
+        <a href="https://letterboxd.com/valenar/" target="_blank" rel="noopener noreferrer">
+          Diario completo su Letterboxd →
+        </a>
+      </p>
 
       <dl class="vw-stats">
         <div class="vw-stat">
-          <dt>Film</dt>
+          <dt>Ultimi visti</dt>
           <dd data-stat="total">{totalCount}</dd>
         </div>
         <div class="vw-stat">


### PR DESCRIPTION
## Cosa cambia
La pagina `/visti` (e `/en/watched`) pretendeva di essere la "lista completa dei film visti" — ma il feed Letterboxd RSS è cappato a ~50 entry, quindi non lo è e non lo sarà mai. Fix di onestà:

| | Prima | Dopo |
|---|---|---|
| Stat "Film" | `Film: 49` | `Ultimi visti: 49` |
| SEO description IT | "Lista completa dei film visti…" | "Ultime visioni dal feed Letterboxd…" |
| SEO description EN | "Full list of films I've watched recently…" | "Latest viewings from my Letterboxd feed…" |
| CTA sotto la lede | – | `Diario completo su Letterboxd →` / `Full diary on Letterboxd →` |

Le altre 3 stat (Ultimi 7 giorni / Ore guardate / Voto medio) restano come sono — sono già contestualizzate dall'eyebrow "Diario di visione" e dalla lede "di recente".

## Stile CTA
Nuova classe `.vw-letterboxd-cta` in `Visti.css` — mono, accento terracotta, underline. Stessa aesthetic Foglio.

## Test
- [x] `astro check`: 0 errori

https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C)_