### PR TITLE
fix(films): nascondi non-fa-ridere dalla griglia film (videogioco intatto)

### DIFF
--- a/src/pages/en/films/index.astro
+++ b/src/pages/en/films/index.astro
@@ -6,6 +6,7 @@ import { getLangFromId, getSlugFromId } from "~/i18n/utils";
 const allFilms = await getCollection("films");
 const films = allFilms
   .filter((e) => getLangFromId(e.id) === "en")
+  .filter((e) => getSlugFromId(e.id) !== "non-fa-ridere")
   .sort((a, b) => a.data.sortOrder - b.data.sortOrder)
   .map((e) => ({
     title: e.data.title,

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -80,6 +80,7 @@ const posts = postsByDate.slice(0, 5);
 const allFilmEntries = await getCollection("films");
 const films = allFilmEntries
   .filter((e) => getLangFromId(e.id) === "en")
+  .filter((e) => getSlugFromId(e.id) !== "non-fa-ridere")
   .sort((a, b) => (a.data.sortOrder ?? 99) - (b.data.sortOrder ?? 99))
   .slice(0, 4)
   .map((e) => ({

--- a/src/pages/films/index.astro
+++ b/src/pages/films/index.astro
@@ -6,6 +6,7 @@ import { getLangFromId, getSlugFromId } from "~/i18n/utils";
 const allFilms = await getCollection("films");
 const films = allFilms
   .filter((e) => getLangFromId(e.id) === "it")
+  .filter((e) => getSlugFromId(e.id) !== "non-fa-ridere")
   .sort((a, b) => a.data.sortOrder - b.data.sortOrder)
   .map((e) => ({
     title: e.data.title,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -87,6 +87,7 @@ const posts = postsByDate.slice(0, 5);
 const allFilmEntries = await getCollection("films");
 const films = allFilmEntries
   .filter((e) => getLangFromId(e.id) === "it")
+  .filter((e) => getSlugFromId(e.id) !== "non-fa-ridere")
   .sort((a, b) => (a.data.sortOrder ?? 99) - (b.data.sortOrder ?? 99))
   .slice(0, 4)
   .map((e) => ({


### PR DESCRIPTION
## Cosa cambia
"Non Fa Ridere" (status: in-production) sparisce dalla griglia film:

- `/films/` (IT)
- `/en/films/`
- Home IT (sezione film)
- Home EN (sezione film)

Filtro one-liner: `getSlugFromId(e.id) !== "non-fa-ridere"` su entrambi i lati lingua.

## Cosa NON ho toccato
- `/non-fa-ridere/` e `/en/non-fa-ridere/` — la pagina del videogioco resta intatta come richiesto.
- `/films/non-fa-ridere/` e `/en/films/non-fa-ridere/` — il file markdown del film resta nel content, quindi la pagina del film è ancora raggiungibile via URL diretto (il videogioco la linka internamente). Se vuoi nasconderla anche da lì, dimmelo e droppo i markdown.

## Test
- [x] `astro check`: 0 errori

https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C)_