### PR TITLE
fix(visti): stat box con metriche date-bounded (7g / 30g / ore 30g / voto)

### DIFF
--- a/src/pages/en/watched.astro
+++ b/src/pages/en/watched.astro
@@ -84,17 +84,24 @@ function fmtDate(raw?: string): string {
 
 const totalCount = all.length;
 const oneWeekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+const oneMonthAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
 const lastWeekCount = all.filter((m) => {
   if (!m.watchedDate) return false;
   const t = new Date(m.watchedDate).getTime();
   return Number.isFinite(t) && t >= oneWeekAgo;
 }).length;
-
-const totalMinutes = all.reduce(
-  (s, m) => s + (typeof m.runtime === "number" && m.runtime > 0 ? m.runtime : 0),
-  0,
+const lastMonth = all.filter((m) => {
+  if (!m.watchedDate) return false;
+  const t = new Date(m.watchedDate).getTime();
+  return Number.isFinite(t) && t >= oneMonthAgo;
+});
+const lastMonthCount = lastMonth.length;
+const lastMonthHours = Math.round(
+  lastMonth.reduce(
+    (s, m) => s + (typeof m.runtime === "number" && m.runtime > 0 ? m.runtime : 0),
+    0,
+  ) / 60,
 );
-const totalHours = Math.round(totalMinutes / 60);
 
 const myRatings = all
   .map((m) => (m.rating ? Number(m.rating) : NaN))
@@ -139,16 +146,16 @@ if (myRatings.length > 0) {
 
       <dl class="vw-stats">
         <div class="vw-stat">
-          <dt>Latest watched</dt>
-          <dd data-stat="total">{totalCount}</dd>
-        </div>
-        <div class="vw-stat">
           <dt>Last 7 days</dt>
           <dd data-stat="week">{lastWeekCount}</dd>
         </div>
         <div class="vw-stat">
-          <dt>Hours watched</dt>
-          <dd data-stat="hours">{totalHours} h</dd>
+          <dt>Last 30 days</dt>
+          <dd data-stat="month">{lastMonthCount}</dd>
+        </div>
+        <div class="vw-stat">
+          <dt>Hours last 30d</dt>
+          <dd data-stat="month-hours">{lastMonthHours} h</dd>
         </div>
         <div class="vw-stat">
           <dt>Average rating</dt>

--- a/src/pages/visti.astro
+++ b/src/pages/visti.astro
@@ -84,17 +84,24 @@ function fmtDate(raw?: string): string {
 
 const totalCount = all.length;
 const oneWeekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+const oneMonthAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
 const lastWeekCount = all.filter((m) => {
   if (!m.watchedDate) return false;
   const t = new Date(m.watchedDate).getTime();
   return Number.isFinite(t) && t >= oneWeekAgo;
 }).length;
-
-const totalMinutes = all.reduce(
-  (s, m) => s + (typeof m.runtime === "number" && m.runtime > 0 ? m.runtime : 0),
-  0,
+const lastMonth = all.filter((m) => {
+  if (!m.watchedDate) return false;
+  const t = new Date(m.watchedDate).getTime();
+  return Number.isFinite(t) && t >= oneMonthAgo;
+});
+const lastMonthCount = lastMonth.length;
+const lastMonthHours = Math.round(
+  lastMonth.reduce(
+    (s, m) => s + (typeof m.runtime === "number" && m.runtime > 0 ? m.runtime : 0),
+    0,
+  ) / 60,
 );
-const totalHours = Math.round(totalMinutes / 60);
 
 const myRatings = all
   .map((m) => (m.rating ? Number(m.rating) : NaN))
@@ -139,16 +146,16 @@ if (myRatings.length > 0) {
 
       <dl class="vw-stats">
         <div class="vw-stat">
-          <dt>Ultimi visti</dt>
-          <dd data-stat="total">{totalCount}</dd>
-        </div>
-        <div class="vw-stat">
           <dt>Ultimi 7 giorni</dt>
           <dd data-stat="week">{lastWeekCount}</dd>
         </div>
         <div class="vw-stat">
-          <dt>Ore guardate</dt>
-          <dd data-stat="hours">{totalHours} h</dd>
+          <dt>Ultimi 30 giorni</dt>
+          <dd data-stat="month">{lastMonthCount}</dd>
+        </div>
+        <div class="vw-stat">
+          <dt>Ore ultimi 30g</dt>
+          <dd data-stat="month-hours">{lastMonthHours} h</dd>
         </div>
         <div class="vw-stat">
           <dt>Voto medio</dt>


### PR DESCRIPTION
## Cosa cambia
Il box stats del `/visti` (e `/en/watched`) ora mostra metriche **date-bounded**, sempre accurate indipendentemente dal cap RSS:

| Prima | Dopo |
|---|---|
| Ultimi visti: 49 | **Ultimi 7 giorni**: N |
| Ultimi 7 giorni: N | **Ultimi 30 giorni**: N |
| Ore guardate: 96h | **Ore ultimi 30g**: N h |
| Voto medio: ★ 4.0/5 | Voto medio: ★ 4.0/5 |

EN: Last 7 days / Last 30 days / Hours last 30d / Average rating.

## Perché
Le metriche sulla finestra completa (49 / 96h) dipendevano dal cap RSS Letterboxd (~50 entry) — informativamente inutili. Quelle date-bounded sono comparabili nel tempo (mese su mese) e raccontano il ritmo di visione.

## Test
- [x] `astro check`: 0 errori

https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaFGcAoPxDukZfwEiN8K8C)_